### PR TITLE
Add Python bindings for set/get motor options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.1.0)
+set(BUILD_VERSION 1.1.1)
 
 # Project and library name
 project(jiminy VERSION ${BUILD_VERSION})

--- a/gym_jiminy/setup.py
+++ b/gym_jiminy/setup.py
@@ -1,20 +1,20 @@
 from setuptools import setup, find_packages
 
 setup(name = 'gym_jiminy',
-      version = '1.1',
+      version = '1.1.1',
       license = 'MIT',
       description = 'Python-native interface between OpenAI Gym and Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.0.tar.gz',
+      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.1.tar.gz',
       packages = find_packages('.'),
       package_data = {'gym_jiminy.envs': ['data/**/*']},
       include_package_data = True, # make sure the data folder is included
       install_requires = [
             'gym',
             'stable_baselines',
-            'jiminy-py==1.1'
+            'jiminy-py~=1.1'
             ]
 )

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -9,14 +9,14 @@ class BinaryDistribution(dist.Distribution):
 
 
 setup(name = 'jiminy_py',
-      version = '1.1.0',
+      version = '1.1.1',
       license = 'MIT',
       description = 'Python-native helper methods and wrapping classes for Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.0.tar.gz',
+      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.1.tar.gz',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py.core': ['libjiminy_pywrap.*']},

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -481,9 +481,9 @@ namespace python
             static void visitAbstract(PyClass& cl)
             {
                 cl
+                    .def("set_options", &PyMotorVisitor::setOptions<TMotor>)
                     .def("get_options", &PyMotorVisitor::getOptions<TMotor>,
                                         bp::return_value_policy<bp::return_by_value>())
-                    .def("set_options", &PyMotorVisitor::setOptions<TMotor>)
 
                     .add_property("name", bp::make_function(&AbstractMotorBase::getName,
                                           bp::return_value_policy<bp::copy_const_reference>()))
@@ -542,20 +542,20 @@ namespace python
         ///////////////////////////////////////////////////////////////////////////////
 
         template<typename TMotor>
-        static bp::dict getOptions(TMotor & self)
-        {
-            bp::dict configPy;
-            convertToPy(self.getOptions(), configPy);
-            return configPy;
-        }
-
-        template<typename TMotor>
         static void setOptions(TMotor         & self,
                                bp::dict const & configPy)
         {
             configHolder_t config = self.getOptions();
             convertToC(configPy, config);
             self.setOptions(config);
+        }
+
+        template<typename TMotor>
+        static bp::dict getOptions(TMotor & self)
+        {
+            bp::dict configPy;
+            convertToPy(self.getOptions(), configPy);
+            return configPy;
         }
 
         ///////////////////////////////////////////////////////////////////////////////
@@ -599,9 +599,9 @@ namespace python
             static void visitAbstract(PyClass& cl)
             {
                 cl
+                    .def("set_options", &PySensorVisitor::setOptions<TSensor>)
                     .def("get_options", &PySensorVisitor::getOptions<TSensor>,
                                         bp::return_value_policy<bp::return_by_value>())
-                    .def("set_options", &PySensorVisitor::setOptions<TSensor>)
 
                     .add_property("name", bp::make_function(&AbstractSensorBase::getName,
                                           bp::return_value_policy<bp::copy_const_reference>()))
@@ -657,20 +657,20 @@ namespace python
         ///////////////////////////////////////////////////////////////////////////////
 
         template<typename TSensor>
-        static bp::dict getOptions(TSensor & self)
-        {
-            bp::dict configPy;
-            convertToPy(self.getOptions(), configPy);
-            return configPy;
-        }
-
-        template<typename TSensor>
         static void setOptions(TSensor        & self,
                                bp::dict const & configPy)
         {
             configHolder_t config = self.getOptions();
             convertToC(configPy, config);
             self.setOptions(config);
+        }
+
+        template<typename TSensor>
+        static bp::dict getOptions(TSensor & self)
+        {
+            bp::dict configPy;
+            convertToPy(self.getOptions(), configPy);
+            return configPy;
         }
 
         template<typename TSensor>
@@ -774,9 +774,12 @@ namespace python
                 .def("get_model_options", &PyModelVisitor::getModelOptions,
                                           bp::return_value_policy<bp::return_by_value>())
                 .def("set_model_options", &PyModelVisitor::setModelOptions)
-                .def("get_sensors_options", &PyModelVisitor::getSensorsOptions,
+                .def("set_motors_options", &PyModelVisitor::setMotorsOptions)
+                .def("get_motors_options", &PyModelVisitor::getMotorsOptions,
                                             bp::return_value_policy<bp::return_by_value>())
                 .def("set_sensors_options", &PyModelVisitor::setSensorsOptions)
+                .def("get_sensors_options", &PyModelVisitor::getSensorsOptions,
+                                            bp::return_value_policy<bp::return_by_value>())
 
                 .add_property("pinocchio_model", bp::make_getter(&Model::pncModel_,
                                                  bp::return_internal_reference<>()))
@@ -942,13 +945,21 @@ namespace python
             self.setTelemetryOptions(configTelemetry);
         }
 
-        static bp::dict getSensorsOptions(Model & self)
+        static void setMotorsOptions(Model          & self,
+                                     bp::dict const & configPy)
+        {
+            configHolder_t config;
+            self.getMotorsOptions(config);
+            convertToC(configPy, config);
+            self.setMotorsOptions(config);
+        }
+
+        static bp::dict getMotorsOptions(Model & self)
         {
             configHolder_t config;
             bp::dict configPy;
-            self.getSensorsOptions(config);
+            self.getMotorsOptions(config);
             convertToPy(config, configPy);
-
             return configPy;
         }
 
@@ -959,6 +970,15 @@ namespace python
             self.getSensorsOptions(config);
             convertToC(configPy, config);
             self.setSensorsOptions(config);
+        }
+
+        static bp::dict getSensorsOptions(Model & self)
+        {
+            configHolder_t config;
+            bp::dict configPy;
+            self.getSensorsOptions(config);
+            convertToPy(config, configPy);
+            return configPy;
         }
 
         ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It also allows to install any version of jiminy-py with gym-jiminy having the same minor version tag.