### PR TITLE
Fix various flaws

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.1.4)
+set(BUILD_VERSION 1.1.5)
 
 # Project and library name
 project(jiminy VERSION ${BUILD_VERSION})

--- a/core/include/jiminy/core/AbstractController.h
+++ b/core/include/jiminy/core/AbstractController.h
@@ -227,9 +227,7 @@ namespace jiminy
         ///             of it before flushing the telemetry data at the end of each simulation steps.
         ///
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        virtual void updateTelemetry(float64_t const& t,
-                                     vectorN_t const& q,
-                                     vectorN_t const& v);
+        virtual void updateTelemetry(void);
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
         ///

--- a/core/include/jiminy/core/AbstractSensor.tpp
+++ b/core/include/jiminy/core/AbstractSensor.tpp
@@ -1,11 +1,11 @@
-#include "jiminy/core/Engine.h" // MIN_TIME_STEP and MAX_TIME_STEP
+#include "jiminy/core/Engine.h" // MIN_SIMULATION_TIMESTEP and MAX_SIMULATION_TIMESTEP
 #include "jiminy/core/Model.h"
 #include "jiminy/core/Utilities.h"
 
 namespace jiminy
 {
-    extern float64_t const MIN_TIME_STEP;
-    extern float64_t const MAX_TIME_STEP;
+    extern float64_t const MIN_SIMULATION_TIMESTEP;
+    extern float64_t const MAX_SIMULATION_TIMESTEP;
 
     template <typename T>
     AbstractSensorTpl<T>::AbstractSensorTpl(std::string const & name) :
@@ -340,7 +340,7 @@ namespace jiminy
 
         /* Make sure at least the requested delay plus the maximum time step
            is available to handle the case where the solver goes back in time */
-        float64_t const timeMin = t - sharedHolder_->delayMax_ - MAX_TIME_STEP;
+        float64_t const timeMin = t - sharedHolder_->delayMax_ - MAX_SIMULATION_TIMESTEP;
 
         // Internal buffer memory management
         if (t + std::numeric_limits<float64_t>::epsilon() > sharedHolder_->time_.back())

--- a/core/include/jiminy/core/Engine.h
+++ b/core/include/jiminy/core/Engine.h
@@ -456,7 +456,7 @@ namespace jiminy
         std::vector<vectorN_t> const & getContactForces(void) const;
 
         void getLogDataRaw(std::vector<std::string>             & header,
-                           std::vector<float32_t>               & timestamps,
+                           std::vector<float64_t>               & timestamps,
                            std::vector<std::vector<int32_t> >   & intData,
                            std::vector<std::vector<float32_t> > & floatData);
 
@@ -483,7 +483,7 @@ namespace jiminy
 
         static result_t parseLogBinaryRaw(std::string                          const & filename,
                                           std::vector<std::string>                   & header,
-                                          std::vector<float32_t>                     & timestamps,
+                                          std::vector<float64_t>                     & timestamps,
                                           std::vector<std::vector<int32_t> >         & intData,
                                           std::vector<std::vector<float32_t> >       & floatData);
         static result_t parseLogBinary(std::string              const & filename,

--- a/core/include/jiminy/core/Engine.h
+++ b/core/include/jiminy/core/Engine.h
@@ -78,7 +78,6 @@ namespace jiminy
         uMotor(),
         uInternal(),
         fExternal(),
-        energy(0.0),
         nx_(0),
         nq_(0),
         nv_(0),
@@ -116,7 +115,6 @@ namespace jiminy
             uCommand = vectorN_t::Zero(model.getMotorsNames().size());
             uMotor = vectorN_t::Zero(model.getMotorsNames().size());
             u = vectorN_t::Zero(nv_);
-            energy = 0.0;
 
             // Set the initialization flag
             isInitialized_ = true;
@@ -159,7 +157,6 @@ namespace jiminy
         vectorN_t uMotor;
         vectorN_t uInternal;
         forceVector_t fExternal;
-        float64_t energy;           ///< Energy of the system (kinetic + potential)
 
     private:
         uint32_t nx_;

--- a/core/include/jiminy/core/Engine.h
+++ b/core/include/jiminy/core/Engine.h
@@ -24,8 +24,8 @@ namespace jiminy
 {
     std::string const ENGINE_OBJECT_NAME("HighLevelController");
 
-    extern float64_t const MIN_TIME_STEP;
-    extern float64_t const MAX_TIME_STEP;
+    extern float64_t const MIN_SIMULATION_TIMESTEP;
+    extern float64_t const MAX_SIMULATION_TIMESTEP;
 
     using namespace boost::numeric::odeint;
 
@@ -70,6 +70,7 @@ namespace jiminy
         iter(0),
         t(0.0),
         dt(0.0),
+        t_err(0.0),
         x(),
         dxdt(),
         u(),
@@ -88,7 +89,7 @@ namespace jiminy
 
         void initialize(Model & model)
         {
-            initialize(model, vectorN_t::Zero(model.nx()), MIN_TIME_STEP);
+            initialize(model, vectorN_t::Zero(model.nx()), MIN_SIMULATION_TIMESTEP);
         }
 
         void initialize(Model           & model,
@@ -150,6 +151,7 @@ namespace jiminy
         uint32_t iter;
         float64_t t;
         float64_t dt;
+        float64_t t_err;            ///< Sum of error internal buffer used for Kahan algorithm
         vectorN_t x;
         vectorN_t dxdt;
         vectorN_t u;
@@ -420,7 +422,7 @@ namespace jiminy
         ///          One may specify a negative timestep to use the default update value.
         ///
         /// \param[in] stepSize Duration for which to integrate ; set to negative value to use default update value.
-        result_t step(float64_t const & stepSize = -1);
+        result_t step(float64_t stepSize = -1);
 
         /// \brief Stop the simulation.
         ///

--- a/core/include/jiminy/core/TelemetryRecorder.h
+++ b/core/include/jiminy/core/TelemetryRecorder.h
@@ -52,7 +52,7 @@ namespace jiminy
         ////////////////////////////////////////////////////////////////////////
         result_t writeDataBinary(std::string const & filename);
         static void getData(std::vector<std::string>                   & header,
-                            std::vector<float32_t>                     & timestamps,
+                            std::vector<float64_t>                     & timestamps,
                             std::vector<std::vector<int32_t> >         & intData,
                             std::vector<std::vector<float32_t> >       & floatData,
                             std::vector<AbstractIODevice *>            & flows,
@@ -61,7 +61,7 @@ namespace jiminy
                             int64_t                              const & headerSize,
                             int64_t                                      recordedBytesDataLine = -1);
         void getData(std::vector<std::string>             & header,
-                     std::vector<float32_t>               & timestamps,
+                     std::vector<float64_t>               & timestamps,
                      std::vector<std::vector<int32_t> >   & intData,
                      std::vector<std::vector<float32_t> > & floatData);
     private:

--- a/core/src/AbstractController.cc
+++ b/core/src/AbstractController.cc
@@ -188,9 +188,7 @@ namespace jiminy
         registeredConstants_.clear();
     }
 
-    void AbstractController::updateTelemetry(float64_t const& t,
-                                             vectorN_t const& q,
-                                             vectorN_t const& v)
+    void AbstractController::updateTelemetry(void)
     {
         if (isTelemetryConfigured_)
         {

--- a/core/src/Engine.cc
+++ b/core/src/Engine.cc
@@ -657,6 +657,10 @@ namespace jiminy
                     }
                 }
 
+                /* Increase back the timestep dt if it has been decreased
+                   to a ridiculously small value because of a breakpoint. */
+                dt = std::max(dt, MIN_TIME_STEP);
+
                 if (stepperUpdatePeriod_ > EPS)
                 {
                     // Get the time of the next breakpoint for the ODE solver:

--- a/core/src/Engine.cc
+++ b/core/src/Engine.cc
@@ -1398,9 +1398,6 @@ namespace jiminy
             float64_t fextTangential = frictionCoeff * fextNormal;
             fextInWorld += -fextTangential * vTangential;
 
-            // Make sure that the force never exceeds 1e5 N for the sake of numerical stability
-            fextInWorld = clamp(fextInWorld, -1e5, 1e5);
-
             // Add blending factor
             if (contactOptions_->transitionEps > EPS)
             {

--- a/core/src/Engine.cc
+++ b/core/src/Engine.cc
@@ -1024,15 +1024,15 @@ namespace jiminy
         return stepperState_;
     }
 
-    void logDataRawToEigenMatrix(std::vector<float32_t>               const & timestamps,
+    void logDataRawToEigenMatrix(std::vector<float64_t>               const & timestamps,
                                  std::vector<std::vector<int32_t> >   const & intData,
                                  std::vector<std::vector<float32_t> > const & floatData,
                                  matrixN_t                                  & logData)
     {
         // Never empty since it contains at least the initial state
         logData.resize(timestamps.size(), 1 + intData[0].size() + floatData[0].size());
-        logData.col(0) = Eigen::Matrix<float32_t, 1, Eigen::Dynamic>::Map(
-            timestamps.data(), timestamps.size()).cast<float64_t>();
+        logData.col(0) = Eigen::Matrix<float64_t, 1, Eigen::Dynamic>::Map(
+            timestamps.data(), timestamps.size());
         for (uint32_t i=0; i<intData.size(); i++)
         {
             logData.block(i, 1, 1, intData[i].size()) =
@@ -1048,7 +1048,7 @@ namespace jiminy
     }
 
     void Engine::getLogDataRaw(std::vector<std::string>             & header,
-                               std::vector<float32_t>               & timestamps,
+                               std::vector<float64_t>               & timestamps,
                                std::vector<std::vector<int32_t> >   & intData,
                                std::vector<std::vector<float32_t> > & floatData)
     {
@@ -1058,7 +1058,7 @@ namespace jiminy
     void Engine::getLogData(std::vector<std::string> & header,
                             matrixN_t                & logData)
     {
-        std::vector<float32_t> timestamps;
+        std::vector<float64_t> timestamps;
         std::vector<std::vector<int32_t> > intData;
         std::vector<std::vector<float32_t> > floatData;
         getLogDataRaw(header, timestamps, intData, floatData);
@@ -1127,7 +1127,7 @@ namespace jiminy
 
     result_t Engine::parseLogBinaryRaw(std::string                          const & filename,
                                        std::vector<std::string>                   & header,
-                                       std::vector<float32_t>                     & timestamps,
+                                       std::vector<float64_t>                     & timestamps,
                                        std::vector<std::vector<int32_t> >         & intData,
                                        std::vector<std::vector<float32_t> >       & floatData)
     {
@@ -1212,7 +1212,7 @@ namespace jiminy
                                     std::vector<std::string>       & header,
                                     matrixN_t                      & logData)
     {
-        std::vector<float32_t> timestamps;
+        std::vector<float64_t> timestamps;
         std::vector<std::vector<int32_t> > intData;
         std::vector<std::vector<float32_t> > floatData;
         result_t returnCode = parseLogBinaryRaw(

--- a/core/src/Engine.cc
+++ b/core/src/Engine.cc
@@ -181,13 +181,11 @@ namespace jiminy
 
     void Engine::updateTelemetry(void)
     {
-        /* Update internal state of the stepper.
-           Note that explicit kinematic computation is not needed to get
-           the system energy since they were already done in RNEA. */
+        // Compute the total energy of the system
         Eigen::Ref<vectorN_t const> q = stepperState_.q();
         Eigen::Ref<vectorN_t const> v = stepperState_.v();
-        stepperState_.energy = Engine::kineticEnergy(model_->pncModel_, model_->pncData_, q, v, false)
-            + pinocchio::potentialEnergy(model_->pncModel_, model_->pncData_, q, false);
+        float64_t energy = Engine::kineticEnergy(model_->pncModel_, model_->pncData_, q, v, true);
+        energy += pinocchio::potentialEnergy(model_->pncModel_, model_->pncData_, q, false);
 
         // Update the telemetry internal state
         if (engineOptions_->telemetry.enableConfiguration)
@@ -212,7 +210,7 @@ namespace jiminy
         }
         if (engineOptions_->telemetry.enableEnergy)
         {
-            telemetrySender_.updateValue("energy", stepperState_.energy);
+            telemetrySender_.updateValue("energy", energy);
         }
         controller_->updateTelemetry();
         model_->updateTelemetry();

--- a/core/src/Engine.cc
+++ b/core/src/Engine.cc
@@ -26,6 +26,7 @@ namespace jiminy
 {
     float64_t const MIN_STEPPER_TIMESTEP = 1e-12;
     float64_t const MIN_SIMULATION_TIMESTEP = 1e-6;
+    float64_t const DEFAULT_SIMULATION_TIMESTEP = 1e-3;
     float64_t const MAX_SIMULATION_TIMESTEP = 5e-3;
 
     Engine::Engine(void):
@@ -661,7 +662,7 @@ namespace jiminy
 
                 /* Increase back the timestep dt if it has been decreased
                    to a ridiculously small value because of a breakpoint. */
-                dt = std::max(dt, MIN_SIMULATION_TIMESTEP);
+                dt = std::max(dt, DEFAULT_SIMULATION_TIMESTEP);
 
                 if (stepperUpdatePeriod_ > EPS)
                 {
@@ -698,8 +699,7 @@ namespace jiminy
                     {
                         // Adjust stepsize to end up exactly at the next breakpoint
                         // and prevent steps larger than dtMax
-                        float64_t dt_tmp = tNext - t;
-                        dt = std::min(std::min(dt, dt_tmp), engineOptions_->stepper.dtMax);
+                        dt = min(dt, tNext - t, engineOptions_->stepper.dtMax);
                         if (tNext - (t + dt) < MIN_STEPPER_TIMESTEP)
                         {
                             dt = tNext - t;
@@ -720,6 +720,7 @@ namespace jiminy
                                accelation in the state space instead of SO3^2. */
                             stepperState_.t = t;
                             ++stepperState_.iter;
+
                             // Log every stepper state only if the user asked for
                             if (engineOptions_->stepper.logInternalStepperSteps)
                             {

--- a/core/src/TelemetryRecorder.cc
+++ b/core/src/TelemetryRecorder.cc
@@ -189,7 +189,7 @@ namespace jiminy
     }
 
     void TelemetryRecorder::getData(std::vector<std::string>                   & header,
-                                    std::vector<float32_t>                     & timestamps,
+                                    std::vector<float64_t>                     & timestamps,
                                     std::vector<std::vector<int32_t> >         & intData,
                                     std::vector<std::vector<float32_t> >       & floatData,
                                     std::vector<AbstractIODevice *>            & flows,
@@ -268,7 +268,7 @@ namespace jiminy
                         break;
                     }
 
-                    timestamps.emplace_back(static_cast<float32_t>(timestamp * 1e-6));
+                    timestamps.emplace_back(static_cast<float64_t>(timestamp * 1e-6));
                     intData.emplace_back(intDataLine);
                     floatData.emplace_back(floatDataLine);
                 }
@@ -282,7 +282,7 @@ namespace jiminy
     }
 
     void TelemetryRecorder::getData(std::vector<std::string>             & header,
-                                    std::vector<float32_t>               & timestamps,
+                                    std::vector<float64_t>               & timestamps,
                                     std::vector<std::vector<int32_t> >   & intData,
                                     std::vector<std::vector<float32_t> > & floatData)
     {

--- a/core/src/Utilities.cc
+++ b/core/src/Utilities.cc
@@ -17,13 +17,13 @@
 #include "pinocchio/algorithm/joint-configuration.hpp"
 
 #include "jiminy/core/Utilities.h"
-#include "jiminy/core/Engine.h"     // MIN_TIME_STEP and MAX_TIME_STEP
+#include "jiminy/core/Engine.h"     // MIN_SIMULATION_TIMESTEP and MAX_SIMULATION_TIMESTEP
 
 
 namespace jiminy
 {
-    extern float64_t const MIN_TIME_STEP;
-    extern float64_t const MAX_TIME_STEP;
+    extern float64_t const MIN_SIMULATION_TIMESTEP;
+    extern float64_t const MAX_SIMULATION_TIMESTEP;
 
     // *************** Local Mutex/Lock mechanism ******************
 
@@ -308,7 +308,7 @@ namespace jiminy
            quaternions on SO3 automatically. Note that the time difference must
            not be too small to avoid failure. */
 
-        dt = std::max(MIN_TIME_STEP, dt);
+        dt = std::max(MIN_SIMULATION_TIMESTEP, dt);
         vectorN_t qNext(q.size());
         pinocchio::integrate(model, q, v*dt, qNext);
         qDot = (qNext - q) / dt;

--- a/gym_jiminy/setup.py
+++ b/gym_jiminy/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup, find_packages
 
 setup(name = 'gym_jiminy',
-      version = '1.1.4',
+      version = '1.1.5',
       license = 'MIT',
       description = 'Python-native interface between OpenAI Gym and Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.4.tar.gz',
+      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.5.tar.gz',
       packages = find_packages('.'),
       package_data = {'gym_jiminy.envs': ['data/**/*']},
       include_package_data = True, # make sure the data folder is included

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -9,14 +9,14 @@ class BinaryDistribution(dist.Distribution):
 
 
 setup(name = 'jiminy_py',
-      version = '1.1.4',
+      version = '1.1.5',
       license = 'MIT',
       description = 'Python-native helper methods and wrapping classes for Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.4.tar.gz',
+      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.1.5.tar.gz',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py.core': ['libjiminy_pywrap.*']},

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -1245,13 +1245,14 @@ namespace python
                                    bp::return_value_policy<bp::return_by_value>()))
                 .add_property("u", bp::make_getter(&stepperState_t::u,
                                    bp::return_value_policy<bp::copy_non_const_reference>()))
+                .add_property("u_motor", bp::make_getter(&stepperState_t::uMotor,
+                                           bp::return_value_policy<bp::copy_non_const_reference>()))
                 .add_property("u_command", bp::make_getter(&stepperState_t::uCommand,
                                            bp::return_value_policy<bp::copy_non_const_reference>()))
                 .add_property("u_internal", bp::make_getter(&stepperState_t::uInternal,
                                             bp::return_value_policy<bp::copy_non_const_reference>()))
                 .add_property("f_external", bp::make_getter(&stepperState_t::fExternal,
                                             bp::return_value_policy<bp::copy_non_const_reference>()))
-                .def_readonly("energy", &stepperState_t::energy)
                 ;
         }
 

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -1415,7 +1415,7 @@ namespace python
         ///////////////////////////////////////////////////////////////////////////////
 
         static bp::tuple formatLog(std::vector<std::string>             const & header,
-                                   std::vector<float32_t>               const & timestamps,
+                                   std::vector<float64_t>               const & timestamps,
                                    std::vector<std::vector<int32_t> >         & intData,
                                    std::vector<std::vector<float32_t> >       & floatData,
                                    bool_t                               const & clear_memory = true)
@@ -1432,8 +1432,8 @@ namespace python
             }
 
             // Get Global.Time
-            Eigen::Ref<Eigen::Matrix<float32_t, Eigen::Dynamic, 1> const> timeBuffer =
-                Eigen::Matrix<float32_t, Eigen::Dynamic, 1>::Map(
+            Eigen::Ref<Eigen::Matrix<float64_t, Eigen::Dynamic, 1> const> timeBuffer =
+                Eigen::Matrix<float64_t, Eigen::Dynamic, 1>::Map(
                     timestamps.data(), timestamps.size());
             PyObject * valuePyTime(getNumpyReferenceFromEigenVector(timeBuffer));
             data[header[lastConstantId + 1]] = bp::object(bp::handle<>(PyArray_FROM_OF(valuePyTime, NPY_ARRAY_ENSURECOPY)));
@@ -1491,7 +1491,7 @@ namespace python
         static bp::tuple getLog(Engine & self)
         {
             std::vector<std::string> header;
-            std::vector<float32_t> timestamps;
+            std::vector<float64_t> timestamps;
             std::vector<std::vector<int32_t> > intData;
             std::vector<std::vector<float32_t> > floatData;
             self.getLogDataRaw(header, timestamps, intData, floatData);
@@ -1501,7 +1501,7 @@ namespace python
         static bp::tuple parseLogBinary(std::string const & filename)
         {
             std::vector<std::string> header;
-            std::vector<float32_t> timestamps;
+            std::vector<float64_t> timestamps;
             std::vector<std::vector<int32_t> > intData;
             std::vector<std::vector<float32_t> > floatData;
             result_t returnCode = Engine::parseLogBinaryRaw(filename, header, timestamps, intData, floatData);


### PR DESCRIPTION
This MR fixes various bugs in the simulation leading to poor computational efficiency because of very small internal step size, and wrong acceleration estimation during the projection on the state space.

- No alterating of the stepper state during the update of the telemetry
- Full precision (double) while parsing the data log file (note that the time accuracy is 1us by design)
- Catch the exception raised by the viewer if Gepetto-viewer is closed during a replay, so that it stops the animation without error.