### PR TITLE
[python] Add generic plotting tool for jiminy logs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.2.23)
+set(BUILD_VERSION 1.2.24)
 
 # Add definition of Jiminy version for C++ headers
 add_definitions("-DJIMINY_VERSION=\"${BUILD_VERSION}\"")

--- a/gym_jiminy/setup.py
+++ b/gym_jiminy/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name = 'gym_jiminy',
-      version = '1.2.23',
+      version = '1.2.24',
       license = 'MIT',
       description = 'Python-native interface between OpenAI Gym and Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
@@ -15,6 +15,9 @@ setup(name = 'gym_jiminy',
       install_requires = [
             'gym',
             'stable_baselines',
-            'jiminy-py~=1.2'
+            'jiminy-py~=1.2',
+            'numpy',
+            'pandas',
+            'matplotlib'
       ]
 )

--- a/gym_jiminy/setup.py
+++ b/gym_jiminy/setup.py
@@ -17,7 +17,6 @@ setup(name = 'gym_jiminy',
             'stable_baselines',
             'jiminy-py~=1.2',
             'numpy',
-            'pandas',
             'matplotlib'
       ]
 )

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -19,7 +19,7 @@ class InstallPlatlib(install):
 
 
 setup(name = 'jiminy_py',
-      version = '1.2.23',
+      version = '1.2.24',
       license = 'MIT',
       description = 'Python-native helper methods and wrapping classes for Jiminy open-source simulator.',
       author = 'Alexis Duburcq',

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -30,6 +30,7 @@ setup(name = 'jiminy_py',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py': ['**/*.dll', '**/*.so', '**/*.pyd']},
+      entry_points={'console_scripts': ['jiminy_plot=jiminy_py.plotter:main']},
       include_package_data = True, # make sure the shared library is included
       distclass = BinaryDistribution,
       cmdclass = {'install': InstallPlatlib},

--- a/python/jiminy_py/src/jiminy_py/__init__.py
+++ b/python/jiminy_py/src/jiminy_py/__init__.py
@@ -15,3 +15,5 @@ except ImportError:
 
 # Import core submodule
 from . import core
+
+from .utils import read_log

--- a/python/jiminy_py/src/jiminy_py/__init__.py
+++ b/python/jiminy_py/src/jiminy_py/__init__.py
@@ -15,5 +15,3 @@ except ImportError:
 
 # Import core submodule
 from . import core
-
-from .utils import read_log

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -10,11 +10,10 @@ from .state import State
 from .core import Engine, Robot
 
 def extract_state_from_simulation_log(log_data:tp.Dict, robot:Robot):
-    """
-    @brief      Extract a trajectory object using from raw simulation data.
+    """ Extract a trajectory object using from raw simulation data.
 
     @details    Extract time, joint positions and velocities evolution from log.
-    .
+
     @remark     Note that the quaternion angular velocity vectors are expressed
                 it body frame rather than world frame.
 
@@ -44,8 +43,7 @@ def extract_state_from_simulation_log(log_data:tp.Dict, robot:Robot):
 
 
 def read_log(filename:str) -> tp.Tuple[tp.Dict, tp.Dict]:
-    """
-    Read a logfile from jiminy. This function supports both text (csv)
+    """ Read a logfile from jiminy. This function supports both text (csv)
     and binary log.
 
     Parameters:
@@ -82,8 +80,7 @@ def read_log(filename:str) -> tp.Tuple[tp.Dict, tp.Dict]:
     return data_dict, constants_dict
 
 def is_log_binary(filename):
-    """
-    From https://stackoverflow.com/a/11301631/4820605.
+    """ From https://stackoverflow.com/a/11301631/4820605.
     Return true if the given filename appears to be binary.
     File is considered to be binary if it contains a NULL byte.
     """

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -10,10 +10,11 @@ from .state import State
 from .core import Engine, Robot
 
 def extract_state_from_simulation_log(log_data:tp.Dict, robot:Robot):
-    """ Extract a trajectory object using from raw simulation data.
+    """
+    @brief      Extract a trajectory object using from raw simulation data.
 
     @details    Extract time, joint positions and velocities evolution from log.
-
+    .
     @remark     Note that the quaternion angular velocity vectors are expressed
                 it body frame rather than world frame.
 
@@ -43,7 +44,8 @@ def extract_state_from_simulation_log(log_data:tp.Dict, robot:Robot):
 
 
 def read_log(filename:str) -> tp.Tuple[tp.Dict, tp.Dict]:
-    """ Read a logfile from jiminy. This function supports both text (csv)
+    """
+    Read a logfile from jiminy. This function supports both text (csv)
     and binary log.
 
     Parameters:
@@ -80,8 +82,9 @@ def read_log(filename:str) -> tp.Tuple[tp.Dict, tp.Dict]:
     return data_dict, constants_dict
 
 def is_log_binary(filename):
-    """ From https://stackoverflow.com/a/11301631/4820605.
+    """
     Return true if the given filename appears to be binary.
+    From https://stackoverflow.com/a/11301631/4820605.
     File is considered to be binary if it contains a NULL byte.
     """
     with open(filename, 'rb') as f:

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -7,9 +7,9 @@ from csv import DictReader
 import typing as tp
 
 from .state import State
-from .core import Engine
+from .core import Engine, Robot
 
-def extract_state_from_simulation_log(log_data:tp.Dict, robot:"jiminy_py.core.Robot"):
+def extract_state_from_simulation_log(log_data:tp.Dict, robot:Robot):
     """
     @brief      Extract a trajectory object using from raw simulation data.
 

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -3,11 +3,13 @@
 ## @file jiminy_py/log.py
 
 import numpy as np
+from pandas import read_csv
+import typing as tp
 
 from .state import State
+from .core import Engine
 
-
-def extract_state_from_simulation_log(log_data, robot):
+def extract_state_from_simulation_log(log_data:tp.Dict, robot:"jiminy_py.core.Robot"):
     """
     @brief      Extract a trajectory object using from raw simulation data.
 
@@ -17,7 +19,7 @@ def extract_state_from_simulation_log(log_data, robot):
                 it body frame rather than world frame.
 
     @param[in]  log_data          Data from the log file, in a dictionnary.
-    @param[in]  robot             Jiminy robot. Optional: None if omitted
+    @param[in]  robot             Jiminy robot.
 
     @return     Trajectory dictionary. The actual trajectory corresponds to
                 the field "evolution_robot" and it is a list of State object.
@@ -39,3 +41,47 @@ def extract_state_from_simulation_log(log_data, robot):
     return {'evolution_robot': evolution_robot,
             'robot': robot,
             'use_theoretical_model': False}
+
+
+def read_log(filename:str) -> tp.Tuple[tp.Dict, tp.Dict]:
+    """
+    Read a logfile from jiminy. This function supports both text (csv)
+    and binary log.
+
+    Parameters:
+        - filename: Name of the file to load.
+    Retunrs:
+        - A dictionnary containing the logged values, and a dictionnary
+        containing the constants.
+    """
+    if is_binary(filename):
+        # Read binary file using C++ parser.
+        data_dict, constants_dict = Engine.read_log_binary(filename)
+    else:
+        # Read text csv file.
+        constants_dict = {}
+        with open(filename, 'r') as log:
+            consts = next(log).split(', ')
+            for c in consts:
+                c_split = c.split('=')
+                # Remove line end for last constant.
+                constants_dict[c_split[0]] = c_split[1].strip('\n')
+        # Read data from the log file, skipping the first line (the constants).
+        data = read_csv(filename, skiprows=1).to_dict(orient='list')
+        # Convert every element to array to provide same API as the C++ parser,
+        # removing spaces present before the keys.
+        data_dict = {k.strip() : np.array(v) for k,v in data.items()}
+    return data_dict, constants_dict
+
+def is_binary(filename):
+    """
+    From https://stackoverflow.com/a/11301631/4820605.
+    Return true if the given filename appears to be binary.
+    File is considered to be binary if it contains a NULL byte.
+    FIXME: This approach incorrectly reports UTF-16 as binary.
+    """
+    with open(filename, 'rb') as f:
+        for block in f:
+            if b'\0' in block:
+                return True
+    return False

--- a/python/jiminy_py/src/jiminy_py/plotter.py
+++ b/python/jiminy_py/src/jiminy_py/plotter.py
@@ -5,7 +5,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from fnmatch import filter
 
-from jiminy_py.core import Engine
+import jiminy_py
 
 def main():
     description_str = "Plot data from a jiminy log file using matplotlib.\n" + \
@@ -18,7 +18,7 @@ def main():
     main_arguments, plotting_commands = parser.parse_known_args()
 
     # Load log file.
-    log_data, _ = Engine.read_log(main_arguments.input)
+    log_data, _ = jiminy_py.read_log(main_arguments.input)
 
     # If no plotting commands, display the list of headers instead.
     if len(plotting_commands) == 0:
@@ -62,9 +62,10 @@ def main():
     for i in range(n_plot):
         for name in plotted_elements[i]:
             axs[i].plot(t, log_data[name], label = name)
-    # Add legend to upper left corner.
+    # Add legend and grid.
     for ax in axs:
-        ax.legend(bbox_to_anchor=(1.0, 1.0), loc = 1)
+        ax.set_xlabel('time (s)')
+        ax.legend()
         ax.grid()
     plt.subplots_adjust(bottom=0.05, top=0.98, left=0.06, right=0.98, wspace=0.1, hspace=0.05)
     plt.show()

--- a/python/jiminy_py/src/jiminy_py/plotter.py
+++ b/python/jiminy_py/src/jiminy_py/plotter.py
@@ -5,7 +5,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from fnmatch import filter
 
-import jiminy_py
+from jiminy_py.log import read_log
 
 def main():
     description_str = "Plot data from a jiminy log file using matplotlib.\n" + \
@@ -18,7 +18,7 @@ def main():
     main_arguments, plotting_commands = parser.parse_known_args()
 
     # Load log file.
-    log_data, _ = jiminy_py.read_log(main_arguments.input)
+    log_data, _ = read_log(main_arguments.input)
 
     # If no plotting commands, display the list of headers instead.
     if len(plotting_commands) == 0:

--- a/python/jiminy_py/src/jiminy_py/plotter.py
+++ b/python/jiminy_py/src/jiminy_py/plotter.py
@@ -3,7 +3,7 @@
 import argparse
 import numpy as np
 import matplotlib.pyplot as plt
-from fnmatch import filter
+import fnmatch
 
 from jiminy_py.log import read_log
 
@@ -34,7 +34,7 @@ def main():
         # Expand each element according to regular expression.
         matching_headers = []
         for h in headers:
-            matching_headers.append(sorted(filter(log_data.keys(), h)))
+            matching_headers.append(sorted(fnmatch.filter(log_data.keys(), h)))
         # Get minimum size for number of subplots.
         n_subplots = min([len(l) for l in matching_headers])
         for i in range(n_subplots):
@@ -50,7 +50,7 @@ def main():
         n_rows = n_rows + 1
         n_cols = np.ceil(n_plot / (1.0 * n_rows))
 
-    fig, axs = plt.subplots(nrows=int(n_rows), ncols=int(n_cols), sharex = True)
+    _, axs = plt.subplots(nrows=int(n_rows), ncols=int(n_cols), sharex = True)
 
     if n_plot == 1:
         axs = np.array([axs])

--- a/python/jiminy_py/src/jiminy_py/plotter.py
+++ b/python/jiminy_py/src/jiminy_py/plotter.py
@@ -1,0 +1,74 @@
+# Plot data from a jiminy log file. See inline help for more info.
+
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from fnmatch import filter
+
+from jiminy_py.core import Engine
+
+def main():
+    description_str = "Plot data from a jiminy log file using matplotlib.\n" + \
+                      "Simply specify a list of fields to plot, separated by a colon for plotting on the same subplot.\n" +\
+                      "Example: h1 h2:h3 generates two subplots, one with h1, one with h2 and h3.\n" + \
+                      "Regular expressions can be used. Enter no plot command (only the file name) to view the list of fields available inside the file."
+
+    parser = argparse.ArgumentParser(description = description_str, formatter_class = argparse.RawTextHelpFormatter)
+    parser.add_argument("input", help = "Input logfile.")
+    main_arguments, plotting_commands = parser.parse_known_args()
+
+    # Load log file.
+    log_data, _ = Engine.read_log(main_arguments.input)
+
+    # If no plotting commands, display the list of headers instead.
+    if len(plotting_commands) == 0:
+        print("Available data:")
+        print("\n - ".join(log_data.keys()))
+        exit(0)
+
+    # Parse plotting arguments.
+    plotted_elements = []
+    for cmd in plotting_commands:
+        # Check that the command is valid, i.e. that all elements exits. If it is the case, add it to the list.
+        headers = cmd.split(":")
+        # Expand each element according to regular expression.
+        matching_headers = []
+        for h in headers:
+            matching_headers.append(sorted(filter(log_data.keys(), h)))
+        # Get minimum size for number of subplots.
+        n_subplots = min([len(l) for l in matching_headers])
+        for i in range(n_subplots):
+            plotted_elements.append([l[i] for l in matching_headers])
+
+    # Create figure.
+    n_plot = len(plotted_elements)
+
+    # Arrange plot in rectangular fashion: don't allow for n_cols to be more than n_rows + 2
+    n_cols = n_plot
+    n_rows = 1
+    while n_cols > n_rows + 2:
+        n_rows = n_rows + 1
+        n_cols = np.ceil(n_plot / (1.0 * n_rows))
+
+    fig, axs = plt.subplots(nrows=int(n_rows), ncols=int(n_cols), sharex = True)
+
+    if n_plot == 1:
+        axs = np.array([axs])
+    axs = axs.flatten()
+
+    plt.gcf().canvas.set_window_title(main_arguments.input)
+    t = log_data['Global.Time']
+    # Plot each element.
+    for i in range(n_plot):
+        for name in plotted_elements[i]:
+            axs[i].plot(t, log_data[name], label = name)
+    # Add legend to upper left corner.
+    for ax in axs:
+        ax.legend(bbox_to_anchor=(1.0, 1.0), loc = 1)
+        ax.grid()
+    plt.subplots_adjust(bottom=0.05, top=0.98, left=0.06, right=0.98, wspace=0.1, hspace=0.05)
+    plt.show()
+
+if __name__ == "__main__":
+    main()
+

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -1497,8 +1497,8 @@ namespace python
                 .def("write_log", &PyEngineMultiRobotVisitor::writeLog,
                                   (bp::arg("self"), "filename",
                                    bp::arg("isModeBinary") = true))
-                .def("read_log", &PyEngineMultiRobotVisitor::parseLogBinary, (bp::arg("filename")))
-                .staticmethod("read_log")
+                .def("read_log_binary", &PyEngineMultiRobotVisitor::parseLogBinary, (bp::arg("filename")))
+                .staticmethod("read_log_binary")
 
                 .def("register_force_impulse", &PyEngineMultiRobotVisitor::registerForceImpulse,
                                                (bp::arg("self"), "system_name",


### PR DESCRIPTION
To make jiminy even nicer to use, this PR proposes a simple python tool, `jiminy_plot`, to plot the content of a logfile rapidly using matplotlib. Below is an example of rendering (actual data is meaningless):

```
jiminy_plot  /tmp/example_sagittal.data H*.c*Pos*Body:H*.c*Vel*Body H*.energy
```

![example](https://user-images.githubusercontent.com/16670497/79383229-20fb8380-7f65-11ea-904a-b54a95101983.png)
