### PR TITLE
Various improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.2.25)
+set(BUILD_VERSION 1.2.26)
 
 # Add definition of Jiminy version for C++ headers
 add_definitions("-DJIMINY_VERSION=\"${BUILD_VERSION}\"")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,65 +2,68 @@
 
 ## Jiminy dependencies installation
 
-
 There is not requirement to install `jiminy_py` on linux if one does not want to build it. Nevertheless, this package does not provide the backend viewer `gepetto-gui` (still, the backend `meshcat` is available).
 
 The first step to install `gepetto-gui` is to setup the APT repository `robotpkg` to have access to compiled binaries.
 
 ```bash
-sudo sh -c "echo 'deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub bionic robotpkg' >> /etc/apt/sources.list.d/robotpkg.list" && \
+sh -c "echo 'deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub bionic robotpkg' >> /etc/apt/sources.list.d/robotpkg.list" && \
 curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -
-sudo apt update
+apt update
 ```
 
-Once done, it is straightforward to install the required package;
+Once done, it is straightforward to install the required package for Python 2.7 or 3.6.
+
+For Python 2.7
 
 ```bash
 sudo apt install -y robotpkg-gepetto-viewer=4.4.0 robotpkg-py27-qt4-gepetto-viewer-corba=5.1.2 robotpkg-py27-omniorbpy
 ```
 
-### Gym Jiminy dependencies (Python 3 only)
-
-#### Tensorflow>=1.13 with GPU support dependencies (Cuda 10.1 and CuDNN 7.6)
-
-Amazing tutorial: <https://medium.com/better-programming/install-tensorflow-1-13-on-ubuntu-18-04-with-gpu-support-239b36d29070>
-
-#### Open AI Gym along with some toy models
+For Python 3.6
 
 ```bash
-pip install gym[atari,box2d,classic_control]
+sudo apt install -y robotpkg-gepetto-viewer=4.4.0 robotpkg-py36-qt4-gepetto-viewer-corba=5.1.2 robotpkg-py36-omniorbpy
 ```
 
-#### Open AI Gym Stable-Baseline
+### Gym Jiminy dependencies (Python 3 only)
+
+#### Tensorflow>=1.13 (stable_baselines requires <= 1.14) with GPU support dependencies (Cuda 10.1 and CuDNN 7.6)
+
+Amazing tutorial for Ubuntu 18: <https://medium.com/better-programming/install-tensorflow-1-13-on-ubuntu-18-04-with-gpu-support-239b36d29070>
+
+#### (optional) Add MPI capability to stable_baselines
 
 ```bash
 pip install stable-baselines[mpi]
 ```
 
-#### Coach dependencies
+#### (optional) Coach dependencies for Ubuntu 18
 
 ```bash
-sudo apt install -y python-opencv
-sudo apt install -y libsdl-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsmpeg-dev libportmidi-dev libavformat-dev libswscale-dev libjpeg-dev  libtiff-dev libsdl1.2-dev libnotify-dev freeglut3 freeglut3-dev libsm-dev libgtk2.0-dev libgtk-3-dev libwebkitgtk-dev libgtk-3-dev libwebkitgtk-3.0-dev libgstreamer-plugins-base1.0-dev
+apt install -y python-opencv
+apt install -y libsdl-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsmpeg-dev libportmidi-dev libavformat-dev libswscale-dev libjpeg-dev  libtiff-dev libsdl1.2-dev libnotify-dev freeglut3 freeglut3-dev libsm-dev libgtk2.0-dev libgtk-3-dev libwebkitgtk-dev libgtk-3-dev libwebkitgtk-3.0-dev libgstreamer-plugins-base1.0-dev
+
 pip install rl_coach
 ```
 
 ## Install Jiminy Python package
 
 The project is available on PyPi and therefore can be install easily using `pip`.
-```
+
+```bash
 python -m pip install jiminy-py
 ```
 
 ## Install Jiminy learning Python package
 
-```
+```bash
 python -m pip install gym-jiminy
 ```
 
 ## (optional) Build Jiminy from source
 
-First, one must install the pre-compiled libraries of the dependencies. Most of them are available on `robotpkg` APT repository. Just run the bash script to install them automatically.
+First, one must install the pre-compiled libraries of the dependencies. Most of them are available on `robotpkg` APT repository. Just run the bash script to install them automatically for Ubuntu 18. It should be straightforward to adapt it to any other distribution for which `robotpkg` is available.
 
 ```bash
 sudo ./jiminy/build_tools/easy_install_deps_ubuntu18.sh

--- a/core/include/jiminy/core/Types.h
+++ b/core/include/jiminy/core/Types.h
@@ -58,9 +58,10 @@ namespace jiminy
 
     // *************** Constant of the universe ******************
 
-    // Define some constant of the universe
+    // Define some aliases for convenience
     float64_t const INF = std::numeric_limits<float64_t>::infinity();
     float64_t const EPS = std::numeric_limits<float64_t>::epsilon();
+    float64_t const qNAN = std::numeric_limits<float64_t>::quiet_NaN();
 
     // *************** Jiminy-specific definitions ***************
 

--- a/core/include/jiminy/core/Types.h
+++ b/core/include/jiminy/core/Types.h
@@ -73,6 +73,19 @@ namespace jiminy
         ERROR_INIT_FAILED = -3
     };
 
+    // Pinocchio joint types
+    enum class joint_t : uint8_t
+    {
+        // CYLINDRICAL are not available so far
+
+        NONE = 0,
+        LINEAR = 1,
+        ROTARY = 2,
+        PLANAR = 3,
+        SPHERICAL = 4,
+        FREE = 5,
+    };
+
     /* Ground profile signature.
        Note that it is impossible to use function pointer since it does not support functors. */
     using heatMapFunctor_t = std::function<std::pair<float64_t, vector3_t>(vector3_t const & /*pos*/)>;

--- a/core/include/jiminy/core/Utilities.h
+++ b/core/include/jiminy/core/Utilities.h
@@ -252,19 +252,6 @@ namespace jiminy
 
     // ******************** Pinocchio utilities *********************
 
-    // Pinocchio joint types
-    enum class joint_t : uint8_t
-    {
-        // CYLINDRICAL are not available so far
-
-        NONE = 0,
-        LINEAR = 1,
-        ROTARY = 2,
-        PLANAR = 3,
-        SPHERICAL = 4,
-        FREE = 5,
-    };
-
     hresult_t computePositionDerivative(pinocchio::Model            const & model,
                                         Eigen::Ref<vectorN_t const> const & q,
                                         Eigen::Ref<vectorN_t const> const & v,

--- a/core/include/jiminy/core/control/AbstractController.h
+++ b/core/include/jiminy/core/control/AbstractController.h
@@ -143,7 +143,7 @@ namespace jiminy
         /// \param[in]  t       Current time
         /// \param[in]  q       Current configuration vector
         /// \param[in]  v       Current velocity vector
-        /// \param[out] u       Output torque vector
+        /// \param[out] u       Output effort vector
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///
@@ -161,7 +161,7 @@ namespace jiminy
         /// \param[in]  t       Current time
         /// \param[in]  q       Current configuration vector
         /// \param[in]  v       Current velocity vector
-        /// \param[in]  u       Output torque vector
+        /// \param[in]  u       Output effort vector
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///

--- a/core/include/jiminy/core/control/ControllerFunctor.h
+++ b/core/include/jiminy/core/control/ControllerFunctor.h
@@ -68,7 +68,7 @@ namespace jiminy
         /// \param[in]  t       Current time
         /// \param[in]  q       Current configuration vector
         /// \param[in]  v       Current velocity vector
-        /// \param[out] u       Output torque vector
+        /// \param[out] u       Output effort vector
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///
@@ -86,7 +86,7 @@ namespace jiminy
         /// \param[in]  t       Current time
         /// \param[in]  q       Current configuration vector
         /// \param[in]  v       Current velocity vector
-        /// \param[in]  u       Output torque vector
+        /// \param[in]  u       Output effort vector
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///

--- a/core/include/jiminy/core/engine/EngineMultiRobot.h
+++ b/core/include/jiminy/core/engine/EngineMultiRobot.h
@@ -246,7 +246,7 @@ namespace jiminy
         std::vector<std::string> positionFieldnames;
         std::vector<std::string> velocityFieldnames;
         std::vector<std::string> accelerationFieldnames;
-        std::vector<std::string> motorTorqueFieldnames;
+        std::vector<std::string> motorEffortFieldnames;
         std::string energyFieldname;
 
     private:
@@ -324,7 +324,7 @@ namespace jiminy
             config["enableConfiguration"] = true;
             config["enableVelocity"] = true;
             config["enableAcceleration"] = true;
-            config["enableTorque"] = true;
+            config["enableEffort"] = true;
             config["enableEnergy"] = true;
             return config;
         };
@@ -429,14 +429,14 @@ namespace jiminy
             bool_t const enableConfiguration;
             bool_t const enableVelocity;
             bool_t const enableAcceleration;
-            bool_t const enableTorque;
+            bool_t const enableEffort;
             bool_t const enableEnergy;
 
             telemetryOptions_t(configHolder_t const & options) :
             enableConfiguration(boost::get<bool_t>(options.at("enableConfiguration"))),
             enableVelocity(boost::get<bool_t>(options.at("enableVelocity"))),
             enableAcceleration(boost::get<bool_t>(options.at("enableAcceleration"))),
-            enableTorque(boost::get<bool_t>(options.at("enableTorque"))),
+            enableEffort(boost::get<bool_t>(options.at("enableEffort"))),
             enableEnergy(boost::get<bool_t>(options.at("enableEnergy")))
             {
                 // Empty.
@@ -680,7 +680,7 @@ namespace jiminy
         /// \param[in] system System for which to compute the dynamics.
         /// \param[in] q Joint position.
         /// \param[in] v Joint velocity.
-        /// \param[in] u Joint torque.
+        /// \param[in] u Joint effort.
         /// \param[in] fext External forces applied on the system.
         /// \return System acceleration.
         vectorN_t computeAcceleration(systemDataHolder_t & system,

--- a/core/include/jiminy/core/robot/AbstractMotor.h
+++ b/core/include/jiminy/core/robot/AbstractMotor.h
@@ -188,6 +188,13 @@ namespace jiminy
         int32_t const & getJointModelIdx(void) const;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
+        /// \brief      Get jointType_.
+        ///
+        /// \details    It is the type of joint associated with the motor.
+        ///////////////////////////////////////////////////////////////////////////////////////////////
+        joint_t const & getJointType(void) const;
+
+        ///////////////////////////////////////////////////////////////////////////////////////////////
         /// \brief      Get jointPositionIdx_.
         ///
         /// \details    It is the index of the joint associated with the motor in the configuration vector.
@@ -290,6 +297,7 @@ namespace jiminy
         int32_t motorIdx_;                           ///< Index of the motor in the measurement buffer
         std::string jointName_;
         int32_t jointModelIdx_;
+        joint_t jointType_;
         int32_t jointPositionIdx_;
         int32_t jointVelocityIdx_;
         float64_t effortLimit_;

--- a/core/include/jiminy/core/robot/AbstractMotor.h
+++ b/core/include/jiminy/core/robot/AbstractMotor.h
@@ -41,7 +41,7 @@ namespace jiminy
 
         ~MotorSharedDataHolder_t(void) = default;
 
-        vectorN_t data_;                            ///< Buffer with current actual motor torque
+        vectorN_t data_;                            ///< Buffer with current actual motor effort
         std::vector<AbstractMotorBase *> motors_;   ///< Vector of pointers to the motors
         int32_t num_;                               ///< Number of motors
     };
@@ -58,9 +58,9 @@ namespace jiminy
         virtual configHolder_t getDefaultMotorOptions(void)
         {
             configHolder_t config;
-            config["enableTorqueLimit"] = true;
-            config["torqueLimitFromUrdf"] = true;
-            config["torqueLimit"] = 0.0;
+            config["enableEffortLimit"] = true;
+            config["effortLimitFromUrdf"] = true;
+            config["effortLimit"] = 0.0;
             config["enableRotorInertia"] = false;
             config["rotorInertia"] = 0.0;
 
@@ -70,16 +70,16 @@ namespace jiminy
     public:
         struct abstractMotorOptions_t
         {
-            bool_t    const enableTorqueLimit;
-            bool_t    const torqueLimitFromUrdf;
-            float64_t const torqueLimit;
+            bool_t    const enableEffortLimit;
+            bool_t    const effortLimitFromUrdf;
+            float64_t const effortLimit;
             bool_t    const enableRotorInertia;
             float64_t const rotorInertia;
 
             abstractMotorOptions_t(configHolder_t const & options) :
-            enableTorqueLimit(boost::get<bool_t>(options.at("enableTorqueLimit"))),
-            torqueLimitFromUrdf(boost::get<bool_t>(options.at("torqueLimitFromUrdf"))),
-            torqueLimit(boost::get<float64_t>(options.at("torqueLimit"))),
+            enableEffortLimit(boost::get<bool_t>(options.at("enableEffortLimit"))),
+            effortLimitFromUrdf(boost::get<bool_t>(options.at("effortLimitFromUrdf"))),
+            effortLimit(boost::get<float64_t>(options.at("effortLimit"))),
             enableRotorInertia(boost::get<bool_t>(options.at("enableRotorInertia"))),
             rotorInertia(boost::get<float64_t>(options.at("rotorInertia")))
             {
@@ -129,12 +129,12 @@ namespace jiminy
         configHolder_t getOptions(void) const;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        /// \brief      Get the actual torque of the motor at the current time.
+        /// \brief      Get the actual effort of the motor at the current time.
         ///////////////////////////////////////////////////////////////////////////////////////////////
         float64_t const & get(void) const;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        /// \brief      Get the actual torque of all the motors at the current time.
+        /// \brief      Get the actual effort of all the motors at the current time.
         ///////////////////////////////////////////////////////////////////////////////////////////////
         vectorN_t const & getAll(void) const;
 
@@ -202,11 +202,11 @@ namespace jiminy
         int32_t const & getJointVelocityIdx(void) const;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        /// \brief      Get torqueLimit_.
+        /// \brief      Get effortLimit_.
         ///
-        /// \details    It is the maximum torque of the motor.
+        /// \details    It is the maximum effort of the motor.
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        float64_t const & getTorqueLimit(void) const;
+        float64_t const & getEffortLimit(void) const;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
         /// \brief      Get rotorInertia_.
@@ -216,7 +216,7 @@ namespace jiminy
         float64_t const & getRotorInertia(void) const;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        /// \brief      Request the motor to update its actual torque based of the input data.
+        /// \brief      Request the motor to update its actual effort based of the input data.
         ///
         /// \details    It assumes that the internal state of the robot is consistent with the
         ///             input arguments.
@@ -225,7 +225,7 @@ namespace jiminy
         /// \param[in]  q       Current configuration of the motor
         /// \param[in]  v       Current velocity of the motor
         /// \param[in]  a       Current acceleration of the motor
-        /// \param[in]  u       Current command torque of the motor
+        /// \param[in]  u       Current command effort of the motor
         ///
         ///////////////////////////////////////////////////////////////////////////////////////////////
         virtual hresult_t computeEffort(float64_t const & t,
@@ -235,7 +235,7 @@ namespace jiminy
                                         float64_t const & uCommand) = 0;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        /// \brief      Request every motors to update their actual torque based of the input data.
+        /// \brief      Request every motors to update their actual effort based of the input data.
         ///
         /// \details    It assumes that the internal state of the robot is consistent with the
         ///             input arguments.
@@ -247,7 +247,7 @@ namespace jiminy
         /// \param[in]  q       Current configuration vector
         /// \param[in]  v       Current velocity vector
         /// \param[in]  a       Current acceleration vector
-        /// \param[in]  u       Current command torque vector
+        /// \param[in]  u       Current command effort vector
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -259,7 +259,7 @@ namespace jiminy
 
     protected:
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        /// \brief      Get a reference to the last data buffer corresponding to the actual torque
+        /// \brief      Get a reference to the last data buffer corresponding to the actual effort
         ///             of the motor.
         ///////////////////////////////////////////////////////////////////////////////////////////////
         float64_t & data(void);
@@ -292,7 +292,7 @@ namespace jiminy
         int32_t jointModelIdx_;
         int32_t jointPositionIdx_;
         int32_t jointVelocityIdx_;
-        float64_t torqueLimit_;
+        float64_t effortLimit_;
         float64_t rotorInertia_;
 
     private:

--- a/core/include/jiminy/core/robot/AbstractSensor.h
+++ b/core/include/jiminy/core/robot/AbstractSensor.h
@@ -234,7 +234,7 @@ namespace jiminy
         /// \param[in]  q       Current configuration vector
         /// \param[in]  v       Current velocity vector
         /// \param[in]  a       Current acceleration vector
-        /// \param[in]  u       Current motor torque vector
+        /// \param[in]  u       Current motor effort vector
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///
@@ -346,7 +346,7 @@ namespace jiminy
         /// \param[in]  q       Current configuration vector
         /// \param[in]  v       Current velocity vector
         /// \param[in]  a       Current acceleration vector
-        /// \param[in]  uMotor  Current motor torque vector
+        /// \param[in]  uMotor  Current motor effort vector
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///

--- a/core/include/jiminy/core/robot/BasicSensors.h
+++ b/core/include/jiminy/core/robot/BasicSensors.h
@@ -93,11 +93,11 @@ namespace jiminy
         int32_t jointVelocityIdx_;
     };
 
-    class TorqueSensor : public AbstractSensorTpl<TorqueSensor>
+    class EffortSensor : public AbstractSensorTpl<EffortSensor>
     {
     public:
-        TorqueSensor(std::string const & name);
-        ~TorqueSensor(void) = default;
+        EffortSensor(std::string const & name);
+        ~EffortSensor(void) = default;
 
         auto shared_from_this() { return shared_from(this); }
 

--- a/core/include/jiminy/core/robot/BasicSensors.h
+++ b/core/include/jiminy/core/robot/BasicSensors.h
@@ -23,6 +23,7 @@ namespace jiminy
         virtual hresult_t refreshProxies(void) final override;
 
         std::string const & getFrameName(void) const;
+        int32_t const & getFrameIdx(void) const;
 
     private:
         virtual hresult_t set(float64_t                   const & t,
@@ -49,6 +50,7 @@ namespace jiminy
         virtual hresult_t refreshProxies(void) final override;
 
         std::string const & getFrameName(void) const;
+        int32_t const & getFrameIdx(void) const;
 
     private:
         virtual hresult_t set(float64_t                   const & t,
@@ -75,6 +77,8 @@ namespace jiminy
         virtual hresult_t refreshProxies(void) final override;
 
         std::string const & getJointName(void) const;
+        int32_t const & getJointPositionIdx(void) const;
+        int32_t const & getJointVelocityIdx(void) const;
 
     private:
         virtual hresult_t set(float64_t                   const & t,
@@ -102,6 +106,7 @@ namespace jiminy
         virtual hresult_t refreshProxies(void) final override;
 
         std::string const & getMotorName(void) const;
+        int32_t const & getMotorIdx(void) const;
 
     private:
         virtual hresult_t set(float64_t                   const & t,

--- a/core/include/jiminy/core/robot/Model.h
+++ b/core/include/jiminy/core/robot/Model.h
@@ -147,9 +147,9 @@ namespace jiminy
         std::vector<std::string> const & getFlexibleJointsNames(void) const;
         std::vector<int32_t> const & getFlexibleJointsModelIdx(void) const;
 
-        vectorN_t const & getJointsPositionLimitMin(void) const;
-        vectorN_t const & getJointsPositionLimitMax(void) const;
-        vectorN_t const & getJointsVelocityLimit(void) const;
+        vectorN_t const & getPositionLimitMin(void) const;
+        vectorN_t const & getPositionLimitMax(void) const;
+        vectorN_t const & getVelocityLimit(void) const;
 
         std::vector<std::string> const & getPositionFieldnames(void) const;
         std::vector<std::string> const & getVelocityFieldnames(void) const;
@@ -186,14 +186,14 @@ namespace jiminy
         std::vector<int32_t> contactFramesIdx_;             ///< Indices of the contact frames in the frame list of the robot
         std::vector<std::string> rigidJointsNames_;         ///< Name of the actual joints of the robot, not taking into account the freeflyer
         std::vector<int32_t> rigidJointsModelIdx_;          ///< Index of the actual joints in the pinocchio robot
-        std::vector<int32_t> rigidJointsPositionIdx_;       ///< All the indices of the actual joints in the configuration vector of the robot
-        std::vector<int32_t> rigidJointsVelocityIdx_;       ///< All the indices of the actual joints in the velocity vector of the robot
+        std::vector<int32_t> rigidJointsPositionIdx_;       ///< All the indices of the actual joints in the configuration vector of the robot (ie including all the degrees of freedom)
+        std::vector<int32_t> rigidJointsVelocityIdx_;       ///< All the indices of the actual joints in the velocity vector of the robot (ie including all the degrees of freedom)
         std::vector<std::string> flexibleJointsNames_;      ///< Name of the flexibility joints of the robot regardless of whether the flexibilities are enable
         std::vector<int32_t> flexibleJointsModelIdx_;       ///< Index of the flexibility joints in the pinocchio robot regardless of whether the flexibilities are enable
 
-        vectorN_t jointsPositionLimitMin_;
-        vectorN_t jointsPositionLimitMax_;
-        vectorN_t jointsVelocityLimit_;
+        vectorN_t positionLimitMin_;                        ///< Upper position limit of the whole configuration vector (INF for "virtual" joints, ie flexibility joints and freeflyer, if any)
+        vectorN_t positionLimitMax_;                        ///< Lower position limit of the whole configuration vector (INF for "virtual" joints, ie flexibility joints and freeflyer, if any)
+        vectorN_t velocityLimit_;                           ///< Maximum absolute velocity of the whole velocity vector (INF for "virtual" joints, ie flexibility joints and freeflyer, if any)
 
         std::vector<std::string> positionFieldnames_;       ///< Fieldnames of the elements in the configuration vector of the rigid robot
         std::vector<std::string> velocityFieldnames_;       ///< Fieldnames of the elements in the velocity vector of the rigid robot

--- a/core/include/jiminy/core/robot/Model.h
+++ b/core/include/jiminy/core/robot/Model.h
@@ -147,9 +147,9 @@ namespace jiminy
         std::vector<std::string> const & getFlexibleJointsNames(void) const;
         std::vector<int32_t> const & getFlexibleJointsModelIdx(void) const;
 
-        vectorN_t const & getPositionLimitMin(void) const;
-        vectorN_t const & getPositionLimitMax(void) const;
-        vectorN_t const & getVelocityLimit(void) const;
+        vectorN_t const & getJointsPositionLimitMin(void) const;
+        vectorN_t const & getJointsPositionLimitMax(void) const;
+        vectorN_t const & getJointsVelocityLimit(void) const;
 
         std::vector<std::string> const & getPositionFieldnames(void) const;
         std::vector<std::string> const & getVelocityFieldnames(void) const;
@@ -191,9 +191,9 @@ namespace jiminy
         std::vector<std::string> flexibleJointsNames_;      ///< Name of the flexibility joints of the robot regardless of whether the flexibilities are enable
         std::vector<int32_t> flexibleJointsModelIdx_;       ///< Index of the flexibility joints in the pinocchio robot regardless of whether the flexibilities are enable
 
-        vectorN_t positionLimitMin_;
-        vectorN_t positionLimitMax_;
-        vectorN_t velocityLimit_;
+        vectorN_t jointsPositionLimitMin_;
+        vectorN_t jointsPositionLimitMax_;
+        vectorN_t jointsVelocityLimit_;
 
         std::vector<std::string> positionFieldnames_;       ///< Fieldnames of the elements in the configuration vector of the rigid robot
         std::vector<std::string> velocityFieldnames_;       ///< Fieldnames of the elements in the velocity vector of the rigid robot

--- a/core/include/jiminy/core/robot/Model.h
+++ b/core/include/jiminy/core/robot/Model.h
@@ -191,9 +191,9 @@ namespace jiminy
         std::vector<std::string> flexibleJointsNames_;      ///< Name of the flexibility joints of the robot regardless of whether the flexibilities are enable
         std::vector<int32_t> flexibleJointsModelIdx_;       ///< Index of the flexibility joints in the pinocchio robot regardless of whether the flexibilities are enable
 
-        vectorN_t positionLimitMin_;                        ///< Upper position limit of the whole configuration vector (INF for "virtual" joints, ie flexibility joints and freeflyer, if any)
-        vectorN_t positionLimitMax_;                        ///< Lower position limit of the whole configuration vector (INF for "virtual" joints, ie flexibility joints and freeflyer, if any)
-        vectorN_t velocityLimit_;                           ///< Maximum absolute velocity of the whole velocity vector (INF for "virtual" joints, ie flexibility joints and freeflyer, if any)
+        vectorN_t positionLimitMin_;                        ///< Upper position limit of the whole configuration vector (INF for non-physical joints, ie flexibility joints and freeflyer, if any)
+        vectorN_t positionLimitMax_;                        ///< Lower position limit of the whole configuration vector (INF for non-physical joints, ie flexibility joints and freeflyer, if any)
+        vectorN_t velocityLimit_;                           ///< Maximum absolute velocity of the whole velocity vector (INF for non-physical joints, ie flexibility joints and freeflyer, if any)
 
         std::vector<std::string> positionFieldnames_;       ///< Fieldnames of the elements in the configuration vector of the rigid robot
         std::vector<std::string> velocityFieldnames_;       ///< Fieldnames of the elements in the velocity vector of the rigid robot

--- a/core/include/jiminy/core/robot/Robot.h
+++ b/core/include/jiminy/core/robot/Robot.h
@@ -70,13 +70,13 @@ namespace jiminy
                               std::string const & sensorName);
         hresult_t detachSensors(std::string const & sensorType = {});
 
-        void computeMotorsTorques(float64_t                   const & t,
+        void computeMotorsEfforts(float64_t                   const & t,
                                   Eigen::Ref<vectorN_t const> const & q,
                                   Eigen::Ref<vectorN_t const> const & v,
                                   vectorN_t                   const & a, // Do Not use Eigen::Ref for the acceleration to avoid memory allocation by the engine for a temporary
                                   vectorN_t                   const & u);
-        vectorN_t const & getMotorsTorques(void) const;
-        float64_t const & getMotorTorque(std::string const & motorName) const;
+        vectorN_t const & getMotorsEfforts(void) const;
+        float64_t const & getMotorEffort(std::string const & motorName) const;
         void setSensorsData(float64_t                   const & t,
                             Eigen::Ref<vectorN_t const> const & q,
                             Eigen::Ref<vectorN_t const> const & v,
@@ -169,10 +169,10 @@ namespace jiminy
         std::unordered_map<std::string, std::vector<std::string> > const & getSensorsNames(void) const;
         std::vector<std::string> const & getSensorsNames(std::string const & sensorType) const;
 
-        vectorN_t getTorqueLimit(void) const;
+        vectorN_t getEffortLimit(void) const;
         vectorN_t getMotorInertia(void) const;
 
-        std::vector<std::string> const & getMotorTorqueFieldnames(void) const;
+        std::vector<std::string> const & getMotorEffortFieldnames(void) const;
 
         hresult_t getLock(std::unique_ptr<MutexLocal::LockGuardLocal> & lock);
         bool_t const & getIsLocked(void) const;
@@ -192,7 +192,7 @@ namespace jiminy
         std::unordered_map<std::string, bool_t> sensorTelemetryOptions_;
         std::vector<std::string> motorsNames_;              ///< Name of the motors of the robot
         std::unordered_map<std::string, std::vector<std::string> > sensorsNames_;   ///<Name of the sensors of the robot
-        std::vector<std::string> motorTorqueFieldnames_;    ///< Fieldnames of the torques of the motors
+        std::vector<std::string> motorEffortFieldnames_;    ///< Fieldnames of the efforts of the motors
 
         std::vector<robotConstraint_t> constraintsHolder_;
         matrixN_t constraintsJacobian_; ///< Matrix holding the jacobian of the constraints.

--- a/core/include/jiminy/core/robot/Robot.h
+++ b/core/include/jiminy/core/robot/Robot.h
@@ -190,13 +190,13 @@ namespace jiminy
         motorsHolder_t motorsHolder_;
         sensorsGroupHolder_t sensorsGroupHolder_;
         std::unordered_map<std::string, bool_t> sensorTelemetryOptions_;
-        std::vector<std::string> motorsNames_;              ///< Name of the motors of the robot
+        std::vector<std::string> motorsNames_;                                      ///< Name of the motors of the robot
         std::unordered_map<std::string, std::vector<std::string> > sensorsNames_;   ///<Name of the sensors of the robot
-        std::vector<std::string> motorEffortFieldnames_;    ///< Fieldnames of the efforts of the motors
+        std::vector<std::string> motorEffortFieldnames_;                            ///< Fieldnames of the efforts of the motors
 
         std::vector<robotConstraint_t> constraintsHolder_;
-        matrixN_t constraintsJacobian_; ///< Matrix holding the jacobian of the constraints.
-        vectorN_t constraintsDrift_;    ///< Vector holding the drift of the constraints.
+        matrixN_t constraintsJacobian_;                                             ///< Matrix holding the jacobian of the constraints.
+        vectorN_t constraintsDrift_;                                                ///< Vector holding the drift of the constraints.
 
     private:
         MutexLocal mutexLocal_;

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -1113,7 +1113,7 @@ namespace jiminy
                                 dt -= dtResidual;
                             }
                         }
-                        
+
                         // Break the loop if dt is getting too small. Don't worry it will be catched later.
                         if (dt < STEPPER_MIN_TIMESTEP)
                         {
@@ -1768,8 +1768,8 @@ namespace jiminy
         if (system.robot->mdlOptions_->joints.enablePositionLimit)
         {
             std::vector<int32_t> const & rigidIdx = system.robot->getRigidJointsModelIdx();
-            vectorN_t const & positionLimitMin = system.robot->getPositionLimitMin();
-            vectorN_t const & positionLimitMax = system.robot->getPositionLimitMax();
+            vectorN_t const & jointsPositionLimitMin = system.robot->getJointsPositionLimitMin();
+            vectorN_t const & jointsPositionLimitMax = system.robot->getJointsPositionLimitMax();
             uint32_t idxOffset = 0;
             for (uint32_t i = 0; i < rigidIdx.size(); i++)
             {
@@ -1781,8 +1781,8 @@ namespace jiminy
                 {
                     float64_t const & qJoint = q[positionIdx + j];
                     float64_t const & vJoint = v[velocityIdx + j];
-                    float64_t const & qJointMin = positionLimitMin[idxOffset];
-                    float64_t const & qJointMax = positionLimitMax[idxOffset];
+                    float64_t const & qJointMin = jointsPositionLimitMin[idxOffset];
+                    float64_t const & qJointMax = jointsPositionLimitMax[idxOffset];
 
                     float64_t forceJoint = 0;
                     float64_t qJointError = 0;
@@ -1817,7 +1817,7 @@ namespace jiminy
         if (system.robot->mdlOptions_->joints.enableVelocityLimit)
         {
             std::vector<int32_t> const & rigidIdx = system.robot->getRigidJointsModelIdx();
-            vectorN_t const & velocityLimitMax = system.robot->getVelocityLimit();
+            vectorN_t const & jointsVelocityLimitMax = system.robot->getJointsVelocityLimit();
 
             uint32_t idxOffset = 0U;
             for (uint32_t i = 0; i < rigidIdx.size(); i++)
@@ -1828,8 +1828,8 @@ namespace jiminy
                 for (uint32_t j = 0; j < jointDof; j++)
                 {
                     float64_t const & vJoint = v[velocityIdx + j];
-                    float64_t const & vJointMin = -velocityLimitMax[idxOffset];
-                    float64_t const & vJointMax = velocityLimitMax[idxOffset];
+                    float64_t const & vJointMin = -jointsVelocityLimitMax[idxOffset];
+                    float64_t const & vJointMax = jointsVelocityLimitMax[idxOffset];
 
                     float64_t forceJoint = 0.0;
                     float64_t vJointError = 0.0;

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -59,7 +59,7 @@ namespace jiminy
     positionFieldnames(),
     velocityFieldnames(),
     accelerationFieldnames(),
-    motorTorqueFieldnames(),
+    motorEffortFieldnames(),
     energyFieldname(),
     robotLock(nullptr),
     state(),
@@ -323,8 +323,8 @@ namespace jiminy
                 system.accelerationFieldnames =
                     addCircumfix(system.robot->getAccelerationFieldnames(),
                                  system.name, "", TELEMETRY_DELIMITER);
-                system.motorTorqueFieldnames =
-                    addCircumfix(system.robot->getMotorTorqueFieldnames(),
+                system.motorEffortFieldnames =
+                    addCircumfix(system.robot->getMotorEffortFieldnames(),
                                  system.name, "", TELEMETRY_DELIMITER);
                 system.energyFieldname =
                     addCircumfix("energy",
@@ -360,10 +360,10 @@ namespace jiminy
                 }
                 if (returnCode == hresult_t::SUCCESS)
                 {
-                    if (engineOptions_->telemetry.enableTorque)
+                    if (engineOptions_->telemetry.enableEffort)
                     {
                         returnCode = telemetrySender_.registerVariable(
-                            system.motorTorqueFieldnames,
+                            system.motorEffortFieldnames,
                             system.state.uMotor);
                     }
                 }
@@ -430,9 +430,9 @@ namespace jiminy
                 telemetrySender_.updateValue(system.accelerationFieldnames,
                                              system.state.a);
             }
-            if (engineOptions_->telemetry.enableTorque)
+            if (engineOptions_->telemetry.enableEffort)
             {
-                telemetrySender_.updateValue(system.motorTorqueFieldnames,
+                telemetrySender_.updateValue(system.motorEffortFieldnames,
                                              system.state.uMotor);
             }
             if (engineOptions_->telemetry.enableEnergy)
@@ -706,17 +706,17 @@ namespace jiminy
                 // Initialize the sensor data
                 system.robot->setSensorsData(t, q, v, a, uMotor);
 
-                // Compute the actual motor torque
+                // Compute the actual motor effort
                 computeCommand(system, t, q, v, uCommand);
 
-                // Compute the actual motor torque
-                system.robot->computeMotorsTorques(t, q, v, a, uCommand);
-                uMotor = system.robot->getMotorsTorques();
+                // Compute the actual motor effort
+                system.robot->computeMotorsEfforts(t, q, v, a, uCommand);
+                uMotor = system.robot->getMotorsEfforts();
 
                 // Compute the internal dynamics
                 computeInternalDynamics(system, t, q, v, uInternal);
 
-                // Compute the total torque vector
+                // Compute the total effort vector
                 u = uInternal;
                 for (auto const & motor : system.robot->getMotors())
                 {
@@ -734,7 +734,7 @@ namespace jiminy
                 // Compute the forward kinematics once again, with the updated acceleration
                 computeForwardKinematics(system, q, v, a);
 
-                // Update the sensor data once again, with the updated torque and acceleration
+                // Update the sensor data once again, with the updated effort and acceleration
                 system.robot->setSensorsData(t, q, v, a, uMotor);
             }
 
@@ -1170,7 +1170,7 @@ namespace jiminy
                                  instead of SO3^2.
                                - dtLargestPrev is used to restore the largest step
                                  size in case of a breakpoint requiring lowering it.
-                               - the acceleration and torque at the last successful
+                               - the acceleration and effort at the last successful
                                  iteration is used to update the sensors' data in
                                  case of continuous sensing. */
                             stepperState_.tPrev = t;
@@ -1754,7 +1754,7 @@ namespace jiminy
                                                    Eigen::Ref<vectorN_t const> const & v,
                                                    vectorN_t                         & u) const
     {
-        // Reinitialize the internal torque vector
+        // Reinitialize the internal effort vector
         u.setZero();
 
         // Compute the user-defined internal dynamics
@@ -2053,7 +2053,7 @@ namespace jiminy
 
             /* Update the sensor data if necessary (only for infinite update frequency).
                Note that it is impossible to have access to the current accelerations
-               and torques since they depend on the sensor values themselves. */
+               and efforts since they depend on the sensor values themselves. */
             if (engineOptions_->stepper.sensorsUpdatePeriod < SIMULATION_MIN_TIMESTEP)
             {
                 systemIt->robot->setSensorsData(t, q, v, aPrev, uMotorPrev);
@@ -2066,17 +2066,17 @@ namespace jiminy
                 computeCommand(*systemIt, t, q, v, uCommand);
             }
 
-            /* Compute the actual motor torque.
+            /* Compute the actual motor effort.
                Note that it is impossible to have access to the current accelerations. */
-            systemIt->robot->computeMotorsTorques(t, q, v, aPrev, uCommand);
-            uMotor = systemIt->robot->getMotorsTorques();
+            systemIt->robot->computeMotorsEfforts(t, q, v, aPrev, uCommand);
+            uMotor = systemIt->robot->getMotorsEfforts();
 
             /* Compute the internal dynamics.
                Make sure that the sensor state has been updated beforehand since
                the user-defined internal dynamics may rely on it. */
             computeInternalDynamics(*systemIt, t, q, v, uInternal);
 
-            // Compute the total torque vector
+            // Compute the total effort vector
             u = uInternal;
             for (auto const & motor : systemIt->robot->getMotors())
             {

--- a/core/src/robot/AbstractMotor.cc
+++ b/core/src/robot/AbstractMotor.cc
@@ -18,7 +18,7 @@ namespace jiminy
     jointModelIdx_(-1),
     jointPositionIdx_(-1),
     jointVelocityIdx_(-1),
-    torqueLimit_(0.0),
+    effortLimit_(0.0),
     rotorInertia_(0.0),
     sharedHolder_(nullptr)
     {
@@ -122,13 +122,13 @@ namespace jiminy
         bool_t internalBuffersMustBeUpdated = false;
         if (isInitialized_)
         {
-            bool_t const & torqueLimitFromUrdf = boost::get<bool_t>(motorOptions.at("torqueLimitFromUrdf"));
-            if (!torqueLimitFromUrdf)
+            bool_t const & effortLimitFromUrdf = boost::get<bool_t>(motorOptions.at("effortLimitFromUrdf"));
+            if (!effortLimitFromUrdf)
             {
-                float64_t const & torqueLimit = boost::get<float64_t>(motorOptions.at("torqueLimit"));
-                internalBuffersMustBeUpdated |= std::abs(torqueLimit - baseMotorOptions_->torqueLimit) > EPS;
+                float64_t const & effortLimit = boost::get<float64_t>(motorOptions.at("effortLimit"));
+                internalBuffersMustBeUpdated |= std::abs(effortLimit - baseMotorOptions_->effortLimit) > EPS;
             }
-            internalBuffersMustBeUpdated |= (baseMotorOptions_->torqueLimitFromUrdf != torqueLimitFromUrdf);
+            internalBuffersMustBeUpdated |= (baseMotorOptions_->effortLimitFromUrdf != effortLimitFromUrdf);
         }
 
         // Update the motor's options
@@ -178,14 +178,14 @@ namespace jiminy
             ::jiminy::getJointPositionIdx(robot_->pncModel_, jointName_, jointPositionIdx_);
             ::jiminy::getJointVelocityIdx(robot_->pncModel_, jointName_, jointVelocityIdx_);
 
-            // Get the motor torque limits from the URDF or the user options.
-            if (baseMotorOptions_->torqueLimitFromUrdf)
+            // Get the motor effort limits from the URDF or the user options.
+            if (baseMotorOptions_->effortLimitFromUrdf)
             {
-                torqueLimit_ = robot_->pncModel_.effortLimit[jointVelocityIdx_];
+                effortLimit_ = robot_->pncModel_.effortLimit[jointVelocityIdx_];
             }
             else
             {
-                torqueLimit_ = baseMotorOptions_->torqueLimit;
+                effortLimit_ = baseMotorOptions_->effortLimit;
             }
 
             // Get the rotor inertia
@@ -267,9 +267,9 @@ namespace jiminy
         return jointVelocityIdx_;
     }
 
-    float64_t const & AbstractMotorBase::getTorqueLimit(void) const
+    float64_t const & AbstractMotorBase::getEffortLimit(void) const
     {
-        return torqueLimit_;
+        return effortLimit_;
     }
 
     float64_t const & AbstractMotorBase::getRotorInertia(void) const
@@ -290,7 +290,7 @@ namespace jiminy
         {
             if (returnCode == hresult_t::SUCCESS)
             {
-                // Compute the actual torque
+                // Compute the actual effort
                 returnCode = motor->computeEffort(t,
                                                   q[motor->getJointPositionIdx()],
                                                   v[motor->getJointVelocityIdx()],

--- a/core/src/robot/AbstractMotor.cc
+++ b/core/src/robot/AbstractMotor.cc
@@ -16,6 +16,7 @@ namespace jiminy
     motorIdx_(-1),
     jointName_(),
     jointModelIdx_(-1),
+    jointType_(joint_t::NONE),
     jointPositionIdx_(-1),
     jointVelocityIdx_(-1),
     effortLimit_(0.0),
@@ -136,7 +137,7 @@ namespace jiminy
         baseMotorOptions_ = std::make_unique<abstractMotorOptions_t const>(motorOptionsHolder_);
 
         // Refresh the proxies if the robot is initialized
-        if (isAttached_ && internalBuffersMustBeUpdated && robot_->getIsInitialized())
+        if (internalBuffersMustBeUpdated && robot_->getIsInitialized() && isAttached_)
         {
             refreshProxies();
         }
@@ -171,6 +172,21 @@ namespace jiminy
         if (returnCode == hresult_t::SUCCESS)
         {
             returnCode = ::jiminy::getJointModelIdx(robot_->pncModel_, jointName_, jointModelIdx_);
+        }
+
+        if (returnCode == hresult_t::SUCCESS)
+        {
+            returnCode = getJointTypeFromIdx(robot_->pncModel_, jointModelIdx_, jointType_);
+        }
+
+        if (returnCode == hresult_t::SUCCESS)
+        {
+            // Motors are only supported for linear and rotary joints
+            if (jointType_ != joint_t::LINEAR && jointType_ != joint_t::ROTARY)
+            {
+                std::cout << "Error - AbstractMotorBase::refreshProxies - A motor can only be associated with a linear or rotary joint." << std::endl;
+                returnCode =  hresult_t::ERROR_BAD_INPUT;
+            }
         }
 
         if (returnCode == hresult_t::SUCCESS)
@@ -255,6 +271,11 @@ namespace jiminy
     int32_t const & AbstractMotorBase::getJointModelIdx(void) const
     {
         return jointModelIdx_;
+    }
+
+    joint_t const & AbstractMotorBase::getJointType(void) const
+    {
+        return jointType_;
     }
 
     int32_t const & AbstractMotorBase::getJointPositionIdx(void) const

--- a/core/src/robot/BasicMotors.cc
+++ b/core/src/robot/BasicMotors.cc
@@ -98,17 +98,17 @@ namespace jiminy
     {
         if (!isInitialized_)
         {
-            std::cout << "Error - SimpleMotor::computeEffort - Motor not initialized. Impossible to compute actual motor torque." << std::endl;
+            std::cout << "Error - SimpleMotor::computeEffort - Motor not initialized. Impossible to compute actual motor effort." << std::endl;
             return hresult_t::ERROR_INIT_FAILED;
         }
 
         // Bypass
         data() = uCommand;
 
-        // Enforce the torque limits
-        if (motorOptions_->enableTorqueLimit)
+        // Enforce the effort limits
+        if (motorOptions_->enableEffortLimit)
         {
-            data() = clamp(data(), -getTorqueLimit(), getTorqueLimit());
+            data() = clamp(data(), -getEffortLimit(), getEffortLimit());
         }
 
         // Add friction to the joints associated with the motor if enable

--- a/core/src/robot/BasicSensors.cc
+++ b/core/src/robot/BasicSensors.cc
@@ -317,16 +317,16 @@ namespace jiminy
         return hresult_t::SUCCESS;
     }
 
-    // ===================== TorqueSensor =========================
+    // ===================== EffortSensor =========================
 
     template<>
-    std::string const AbstractSensorTpl<TorqueSensor>::type_("TorqueSensor");
+    std::string const AbstractSensorTpl<EffortSensor>::type_("EffortSensor");
     template<>
-    bool_t const AbstractSensorTpl<TorqueSensor>::areFieldnamesGrouped_(true);
+    bool_t const AbstractSensorTpl<EffortSensor>::areFieldnamesGrouped_(true);
     template<>
-    std::vector<std::string> const AbstractSensorTpl<TorqueSensor>::fieldNames_({"U"});
+    std::vector<std::string> const AbstractSensorTpl<EffortSensor>::fieldNames_({"U"});
 
-    TorqueSensor::TorqueSensor(std::string const & name) :
+    EffortSensor::EffortSensor(std::string const & name) :
     AbstractSensorTpl(name),
     motorName_(),
     motorIdx_(0)
@@ -334,13 +334,13 @@ namespace jiminy
         // Empty.
     }
 
-    hresult_t TorqueSensor::initialize(std::string const & motorName)
+    hresult_t EffortSensor::initialize(std::string const & motorName)
     {
         hresult_t returnCode = hresult_t::SUCCESS;
 
         if (!isAttached_)
         {
-            std::cout << "Error - TorqueSensor::initialize - Sensor not attached to any robot. Impossible to initialize it." << std::endl;
+            std::cout << "Error - EffortSensor::initialize - Sensor not attached to any robot. Impossible to initialize it." << std::endl;
             returnCode = hresult_t::ERROR_GENERIC;
         }
 
@@ -359,19 +359,19 @@ namespace jiminy
         return returnCode;
     }
 
-    hresult_t TorqueSensor::refreshProxies(void)
+    hresult_t EffortSensor::refreshProxies(void)
     {
         hresult_t returnCode = hresult_t::SUCCESS;
 
         if (!robot_->getIsInitialized())
         {
-            std::cout << "Error - TorqueSensor::refreshProxies - Robot not initialized. Impossible to refresh model-dependent proxies." << std::endl;
+            std::cout << "Error - EffortSensor::refreshProxies - Robot not initialized. Impossible to refresh model-dependent proxies." << std::endl;
             returnCode = hresult_t::ERROR_INIT_FAILED;
         }
 
         if (!isInitialized_)
         {
-            std::cout << "Error - TorqueSensor::refreshProxies - Sensor not initialized. Impossible to refresh model-dependent proxies." << std::endl;
+            std::cout << "Error - EffortSensor::refreshProxies - Sensor not initialized. Impossible to refresh model-dependent proxies." << std::endl;
             returnCode = hresult_t::ERROR_INIT_FAILED;
         }
 
@@ -389,17 +389,17 @@ namespace jiminy
         return returnCode;
     }
 
-    std::string const & TorqueSensor::getMotorName(void) const
+    std::string const & EffortSensor::getMotorName(void) const
     {
         return motorName_;
     }
 
-    int32_t const & TorqueSensor::getMotorIdx(void) const
+    int32_t const & EffortSensor::getMotorIdx(void) const
     {
         return motorIdx_;
     }
 
-    hresult_t TorqueSensor::set(float64_t                   const & t,
+    hresult_t EffortSensor::set(float64_t                   const & t,
                                 Eigen::Ref<vectorN_t const> const & q,
                                 Eigen::Ref<vectorN_t const> const & v,
                                 Eigen::Ref<vectorN_t const> const & a,
@@ -407,7 +407,7 @@ namespace jiminy
     {
         if (!isInitialized_)
         {
-            std::cout << "Error - TorqueSensor::set - Sensor not initialized. Impossible to set sensor data." << std::endl;
+            std::cout << "Error - EffortSensor::set - Sensor not initialized. Impossible to set sensor data." << std::endl;
             return hresult_t::ERROR_INIT_FAILED;
         }
 

--- a/core/src/robot/BasicSensors.cc
+++ b/core/src/robot/BasicSensors.cc
@@ -75,7 +75,7 @@ namespace jiminy
 
         if (returnCode == hresult_t::SUCCESS)
         {
-            returnCode = getFrameIdx(robot_->pncModel_, frameName_, frameIdx_);
+            returnCode = ::jiminy::getFrameIdx(robot_->pncModel_, frameName_, frameIdx_);
         }
 
         return returnCode;
@@ -84,6 +84,11 @@ namespace jiminy
     std::string const & ImuSensor::getFrameName(void) const
     {
         return frameName_;
+    }
+
+    int32_t const & ImuSensor::getFrameIdx(void) const
+    {
+        return frameIdx_;
     }
 
     hresult_t ImuSensor::set(float64_t                   const & t,
@@ -172,7 +177,7 @@ namespace jiminy
 
         if (returnCode == hresult_t::SUCCESS)
         {
-            returnCode = getFrameIdx(robot_->pncModel_, frameName_, frameIdx_);
+            returnCode = ::jiminy::getFrameIdx(robot_->pncModel_, frameName_, frameIdx_);
         }
 
         return returnCode;
@@ -181,6 +186,11 @@ namespace jiminy
     std::string const & ForceSensor::getFrameName(void) const
     {
         return frameName_;
+    }
+
+    int32_t const & ForceSensor::getFrameIdx(void) const
+    {
+        return frameIdx_;
     }
 
     hresult_t ForceSensor::set(float64_t                   const & t,
@@ -263,12 +273,12 @@ namespace jiminy
 
         if (returnCode == hresult_t::SUCCESS)
         {
-            returnCode = getJointPositionIdx(robot_->pncModel_, jointName_, jointPositionIdx_);
+            returnCode = ::jiminy::getJointPositionIdx(robot_->pncModel_, jointName_, jointPositionIdx_);
         }
 
         if (returnCode == hresult_t::SUCCESS)
         {
-            getJointVelocityIdx(robot_->pncModel_, jointName_, jointVelocityIdx_);
+            ::jiminy::getJointVelocityIdx(robot_->pncModel_, jointName_, jointVelocityIdx_);
         }
 
         return returnCode;
@@ -277,6 +287,16 @@ namespace jiminy
     std::string const & EncoderSensor::getJointName(void) const
     {
         return jointName_;
+    }
+
+    int32_t const & EncoderSensor::getJointPositionIdx(void)  const
+    {
+
+        return jointPositionIdx_;
+    }
+    int32_t const & EncoderSensor::getJointVelocityIdx(void)  const
+    {
+        return jointVelocityIdx_;
     }
 
     hresult_t EncoderSensor::set(float64_t                   const & t,
@@ -372,6 +392,11 @@ namespace jiminy
     std::string const & TorqueSensor::getMotorName(void) const
     {
         return motorName_;
+    }
+
+    int32_t const & TorqueSensor::getMotorIdx(void) const
+    {
+        return motorIdx_;
     }
 
     hresult_t TorqueSensor::set(float64_t                   const & t,

--- a/core/src/robot/Model.cc
+++ b/core/src/robot/Model.cc
@@ -35,9 +35,9 @@ namespace jiminy
     rigidJointsVelocityIdx_(),
     flexibleJointsNames_(),
     flexibleJointsModelIdx_(),
-    jointsPositionLimitMin_(),
-    jointsPositionLimitMax_(),
-    jointsVelocityLimit_(),
+    positionLimitMin_(),
+    positionLimitMax_(),
+    velocityLimit_(),
     positionFieldnames_(),
     velocityFieldnames_(),
     accelerationFieldnames_(),
@@ -432,35 +432,26 @@ namespace jiminy
         if (returnCode == hresult_t::SUCCESS)
         {
             // Get the joint position limits from the URDF or the user options
-            if (mdlOptions_->joints.positionLimitFromUrdf)
+            positionLimitMin_ = pncModel_.lowerPositionLimit;
+            positionLimitMax_ = pncModel_.upperPositionLimit;
+            if (!mdlOptions_->joints.positionLimitFromUrdf)
             {
-                uint8_t const numRigidJoints = rigidJointsPositionIdx_.size();
-                jointsPositionLimitMin_.resize(numRigidJoints);
-                jointsPositionLimitMax_.resize(numRigidJoints);
-                for (uint32_t i=0; i < numRigidJoints; ++i)
+                for (uint32_t i=0; i < rigidJointsPositionIdx_.size(); i++)
                 {
-                    jointsPositionLimitMin_[i] = pncModel_.lowerPositionLimit[rigidJointsPositionIdx_[i]];
-                    jointsPositionLimitMax_[i] = pncModel_.upperPositionLimit[rigidJointsPositionIdx_[i]];
+                    positionLimitMin_[rigidJointsPositionIdx_[i]] = mdlOptions_->joints.positionLimitMin[i];
+                    positionLimitMax_[rigidJointsPositionIdx_[i]] = mdlOptions_->joints.positionLimitMax[i];
                 }
-            }
-            else
-            {
-                jointsPositionLimitMin_ = mdlOptions_->joints.positionLimitMin;
-                jointsPositionLimitMax_ = mdlOptions_->joints.positionLimitMax;
+
             }
 
             // Get the joint velocity limits from the URDF or the user options
-            if (mdlOptions_->joints.velocityLimitFromUrdf)
+            velocityLimit_ = pncModel_.velocityLimit;
+            if (!mdlOptions_->joints.velocityLimitFromUrdf)
             {
-                jointsVelocityLimit_.resize(rigidJointsVelocityIdx_.size());
-                for (uint32_t i=0; i < rigidJointsVelocityIdx_.size(); ++i)
+                for (uint32_t i=0; i < rigidJointsVelocityIdx_.size(); i++)
                 {
-                    jointsVelocityLimit_[i] = pncModel_.velocityLimit[rigidJointsVelocityIdx_[i]];
+                    velocityLimit_[rigidJointsVelocityIdx_[i]] = mdlOptions_->joints.velocityLimit[i];
                 }
-            }
-            else
-            {
-                jointsVelocityLimit_ = mdlOptions_->joints.velocityLimit;
             }
         }
 
@@ -742,14 +733,14 @@ namespace jiminy
         return positionFieldnames_;
     }
 
-    vectorN_t const & Model::getJointsPositionLimitMin(void) const
+    vectorN_t const & Model::getPositionLimitMin(void) const
     {
-        return jointsPositionLimitMin_;
+        return positionLimitMin_;
     }
 
-    vectorN_t const & Model::getJointsPositionLimitMax(void) const
+    vectorN_t const & Model::getPositionLimitMax(void) const
     {
-        return jointsPositionLimitMax_;
+        return positionLimitMax_;
     }
 
     std::vector<std::string> const & Model::getVelocityFieldnames(void) const
@@ -757,9 +748,9 @@ namespace jiminy
         return velocityFieldnames_;
     }
 
-    vectorN_t const & Model::getJointsVelocityLimit(void) const
+    vectorN_t const & Model::getVelocityLimit(void) const
     {
-        return jointsVelocityLimit_;
+        return velocityLimit_;
     }
 
     std::vector<std::string> const & Model::getAccelerationFieldnames(void) const

--- a/core/src/robot/Model.cc
+++ b/core/src/robot/Model.cc
@@ -35,9 +35,9 @@ namespace jiminy
     rigidJointsVelocityIdx_(),
     flexibleJointsNames_(),
     flexibleJointsModelIdx_(),
-    positionLimitMin_(),
-    positionLimitMax_(),
-    velocityLimit_(),
+    jointsPositionLimitMin_(),
+    jointsPositionLimitMax_(),
+    jointsVelocityLimit_(),
     positionFieldnames_(),
     velocityFieldnames_(),
     accelerationFieldnames_(),
@@ -435,32 +435,32 @@ namespace jiminy
             if (mdlOptions_->joints.positionLimitFromUrdf)
             {
                 uint8_t const numRigidJoints = rigidJointsPositionIdx_.size();
-                positionLimitMin_.resize(numRigidJoints);
-                positionLimitMax_.resize(numRigidJoints);
+                jointsPositionLimitMin_.resize(numRigidJoints);
+                jointsPositionLimitMax_.resize(numRigidJoints);
                 for (uint32_t i=0; i < numRigidJoints; ++i)
                 {
-                    positionLimitMin_[i] = pncModel_.lowerPositionLimit[rigidJointsPositionIdx_[i]];
-                    positionLimitMax_[i] = pncModel_.upperPositionLimit[rigidJointsPositionIdx_[i]];
+                    jointsPositionLimitMin_[i] = pncModel_.lowerPositionLimit[rigidJointsPositionIdx_[i]];
+                    jointsPositionLimitMax_[i] = pncModel_.upperPositionLimit[rigidJointsPositionIdx_[i]];
                 }
             }
             else
             {
-                positionLimitMin_ = mdlOptions_->joints.positionLimitMin;
-                positionLimitMax_ = mdlOptions_->joints.positionLimitMax;
+                jointsPositionLimitMin_ = mdlOptions_->joints.positionLimitMin;
+                jointsPositionLimitMax_ = mdlOptions_->joints.positionLimitMax;
             }
 
             // Get the joint velocity limits from the URDF or the user options
             if (mdlOptions_->joints.velocityLimitFromUrdf)
             {
-                velocityLimit_.resize(rigidJointsVelocityIdx_.size());
+                jointsVelocityLimit_.resize(rigidJointsVelocityIdx_.size());
                 for (uint32_t i=0; i < rigidJointsVelocityIdx_.size(); ++i)
                 {
-                    velocityLimit_[i] = pncModel_.velocityLimit[rigidJointsVelocityIdx_[i]];
+                    jointsVelocityLimit_[i] = pncModel_.velocityLimit[rigidJointsVelocityIdx_[i]];
                 }
             }
             else
             {
-                velocityLimit_ = mdlOptions_->joints.velocityLimit;
+                jointsVelocityLimit_ = mdlOptions_->joints.velocityLimit;
             }
         }
 
@@ -504,33 +504,33 @@ namespace jiminy
                 boost::get<configHolder_t>(modelOptions.at("joints"));
             if (!boost::get<bool_t>(jointOptionsHolder.at("positionLimitFromUrdf")))
             {
-                vectorN_t & positionLimitMin = boost::get<vectorN_t>(jointOptionsHolder.at("positionLimitMin"));
-                if ((int32_t) rigidJointsPositionIdx_.size() != positionLimitMin.size())
+                vectorN_t & jointsPositionLimitMin = boost::get<vectorN_t>(jointOptionsHolder.at("positionLimitMin"));
+                if ((int32_t) rigidJointsPositionIdx_.size() != jointsPositionLimitMin.size())
                 {
                     std::cout << "Error - Model::setOptions - Wrong vector size for 'positionLimitMin'." << std::endl;
                     return hresult_t::ERROR_BAD_INPUT;
                 }
-                vectorN_t positionLimitMinDiff = positionLimitMin - mdlOptions_->joints.positionLimitMin;
-                internalBuffersMustBeUpdated |= (positionLimitMinDiff.array().abs() >= EPS).all();
-                vectorN_t & positionLimitMax = boost::get<vectorN_t>(jointOptionsHolder.at("positionLimitMax"));
-                if ((uint32_t) rigidJointsPositionIdx_.size() != positionLimitMax.size())
+                vectorN_t jointsPositionLimitMinDiff = jointsPositionLimitMin - mdlOptions_->joints.positionLimitMin;
+                internalBuffersMustBeUpdated |= (jointsPositionLimitMinDiff.array().abs() >= EPS).all();
+                vectorN_t & jointsPositionLimitMax = boost::get<vectorN_t>(jointOptionsHolder.at("positionLimitMax"));
+                if ((uint32_t) rigidJointsPositionIdx_.size() != jointsPositionLimitMax.size())
                 {
                     std::cout << "Error - Model::setOptions - Wrong vector size for 'positionLimitMax'." << std::endl;
                     return hresult_t::ERROR_BAD_INPUT;
                 }
-                vectorN_t positionLimitMaxDiff = positionLimitMax - mdlOptions_->joints.positionLimitMax;
-                internalBuffersMustBeUpdated |= (positionLimitMaxDiff.array().abs() >= EPS).all();
+                vectorN_t jointsPositionLimitMaxDiff = jointsPositionLimitMax - mdlOptions_->joints.positionLimitMax;
+                internalBuffersMustBeUpdated |= (jointsPositionLimitMaxDiff.array().abs() >= EPS).all();
             }
             if (!boost::get<bool_t>(jointOptionsHolder.at("velocityLimitFromUrdf")))
             {
-                vectorN_t & velocityLimit = boost::get<vectorN_t>(jointOptionsHolder.at("velocityLimit"));
-                if ((int32_t) rigidJointsVelocityIdx_.size() != velocityLimit.size())
+                vectorN_t & jointsVelocityLimit = boost::get<vectorN_t>(jointOptionsHolder.at("velocityLimit"));
+                if ((int32_t) rigidJointsVelocityIdx_.size() != jointsVelocityLimit.size())
                 {
                     std::cout << "Error - Model::setOptions - Wrong vector size for 'velocityLimit'." << std::endl;
                     return hresult_t::ERROR_BAD_INPUT;
                 }
-                vectorN_t velocityLimitDiff = velocityLimit - mdlOptions_->joints.velocityLimit;
-                internalBuffersMustBeUpdated |= (velocityLimitDiff.array().abs() >= EPS).all();
+                vectorN_t jointsVelocityLimitDiff = jointsVelocityLimit - mdlOptions_->joints.velocityLimit;
+                internalBuffersMustBeUpdated |= (jointsVelocityLimitDiff.array().abs() >= EPS).all();
             }
 
             // Check if the flexible model and its associated proxies must be regenerated
@@ -742,14 +742,14 @@ namespace jiminy
         return positionFieldnames_;
     }
 
-    vectorN_t const & Model::getPositionLimitMin(void) const
+    vectorN_t const & Model::getJointsPositionLimitMin(void) const
     {
-        return positionLimitMin_;
+        return jointsPositionLimitMin_;
     }
 
-    vectorN_t const & Model::getPositionLimitMax(void) const
+    vectorN_t const & Model::getJointsPositionLimitMax(void) const
     {
-        return positionLimitMax_;
+        return jointsPositionLimitMax_;
     }
 
     std::vector<std::string> const & Model::getVelocityFieldnames(void) const
@@ -757,9 +757,9 @@ namespace jiminy
         return velocityFieldnames_;
     }
 
-    vectorN_t const & Model::getVelocityLimit(void) const
+    vectorN_t const & Model::getJointsVelocityLimit(void) const
     {
-        return velocityLimit_;
+        return jointsVelocityLimit_;
     }
 
     std::vector<std::string> const & Model::getAccelerationFieldnames(void) const

--- a/core/src/robot/Robot.cc
+++ b/core/src/robot/Robot.cc
@@ -28,7 +28,7 @@ namespace jiminy
     sensorTelemetryOptions_(),
     motorsNames_(),
     sensorsNames_(),
-    motorTorqueFieldnames_(),
+    motorEffortFieldnames_(),
     constraintsHolder_(),
     constraintsJacobian_(),
     constraintsDrift_(),
@@ -644,8 +644,8 @@ namespace jiminy
                                return elem->getName();
                            });
 
-            // Generate the fieldnames associated with the motor torques
-            motorTorqueFieldnames_ = addCircumfix(motorsNames_, JOINT_PREFIX_BASE + "Torque");
+            // Generate the fieldnames associated with the motor efforts
+            motorEffortFieldnames_ = addCircumfix(motorsNames_, JOINT_PREFIX_BASE + "Torque"); // Add "Torque" suffix instead of "Effort" for compatibility with Wandercraft proprietary log analyzer.
         }
 
         return returnCode;
@@ -1251,7 +1251,7 @@ namespace jiminy
         return isTelemetryConfigured_;
     }
 
-    void Robot::computeMotorsTorques(float64_t            const  & t,
+    void Robot::computeMotorsEfforts(float64_t            const  & t,
                                      Eigen::Ref<vectorN_t const> const & q,
                                      Eigen::Ref<vectorN_t const> const & v,
                                      vectorN_t                   const & a,
@@ -1263,21 +1263,21 @@ namespace jiminy
         }
     }
 
-    vectorN_t const & Robot::getMotorsTorques(void) const
+    vectorN_t const & Robot::getMotorsEfforts(void) const
     {
-        static vectorN_t const motorsTorquesEmpty;
+        static vectorN_t const motorsEffortsEmpty;
 
         if (!motorsHolder_.empty())
         {
             return (*motorsHolder_.begin())->getAll();
         }
 
-        return motorsTorquesEmpty;
+        return motorsEffortsEmpty;
     }
 
-    float64_t const & Robot::getMotorTorque(std::string const & motorName) const
+    float64_t const & Robot::getMotorEffort(std::string const & motorName) const
     {
-        static float64_t const motorTorqueEmpty = -1;
+        static float64_t const motorEffortEmpty = -1;
 
         auto motorIt = std::find_if(motorsHolder_.begin(), motorsHolder_.end(),
                                     [&motorName](auto const & elem)
@@ -1289,7 +1289,7 @@ namespace jiminy
             return (*motorIt)->get();
         }
 
-        return motorTorqueEmpty;
+        return motorEffortEmpty;
     }
 
     void Robot::setSensorsData(float64_t                   const & t,
@@ -1471,19 +1471,19 @@ namespace jiminy
         }
     }
 
-    vectorN_t Robot::getTorqueLimit(void) const
+    vectorN_t Robot::getEffortLimit(void) const
     {
-        vectorN_t torqueLimit = vectorN_t::Constant(pncModel_.nv, -1);
+        vectorN_t effortLimit = vectorN_t::Constant(pncModel_.nv, -1);
         for (auto const & motor : motorsHolder_)
         {
             auto const & motorOptions = motor->baseMotorOptions_;
             int32_t const & motorsVelocityIdx = motor->getJointVelocityIdx();
-            if (motorOptions->enableTorqueLimit)
+            if (motorOptions->enableEffortLimit)
             {
-                torqueLimit[motorsVelocityIdx] = motor->getTorqueLimit();
+                effortLimit[motorsVelocityIdx] = motor->getEffortLimit();
             }
         }
-        return torqueLimit;
+        return effortLimit;
     }
 
     vectorN_t Robot::getMotorInertia(void) const
@@ -1497,9 +1497,9 @@ namespace jiminy
         return motorInertia;
     }
 
-    std::vector<std::string> const & Robot::getMotorTorqueFieldnames(void) const
+    std::vector<std::string> const & Robot::getMotorEffortFieldnames(void) const
     {
-        return motorTorqueFieldnames_;
+        return motorEffortFieldnames_;
     }
 
     /// \brief Get jacobian of the constraints.

--- a/core/src/robot/Robot.cc
+++ b/core/src/robot/Robot.cc
@@ -1487,7 +1487,7 @@ namespace jiminy
 
     vectorN_t Robot::getEffortLimit(void) const
     {
-        vectorN_t effortLimit = vectorN_t::Constant(pncModel_.nv, -1);
+        vectorN_t effortLimit = vectorN_t::Constant(pncModel_.nv, qNAN); // Do NOT use robot_->pncModel_.effortLimit, since we don't care about effort limits for non-physical joints
         for (auto const & motor : motorsHolder_)
         {
             auto const & motorOptions = motor->baseMotorOptions_;
@@ -1496,6 +1496,11 @@ namespace jiminy
             {
                 effortLimit[motorsVelocityIdx] = motor->getEffortLimit();
             }
+            else
+            {
+                effortLimit[motorsVelocityIdx] = INF;
+            }
+
         }
         return effortLimit;
     }

--- a/core/src/robot/Robot.cc
+++ b/core/src/robot/Robot.cc
@@ -645,7 +645,21 @@ namespace jiminy
                            });
 
             // Generate the fieldnames associated with the motor efforts
-            motorEffortFieldnames_ = addCircumfix(motorsNames_, JOINT_PREFIX_BASE + "Torque"); // Add "Torque" suffix instead of "Effort" for compatibility with Wandercraft proprietary log analyzer.
+            motorEffortFieldnames_.clear();
+            motorEffortFieldnames_.reserve(motorsHolder_.size());
+            std::transform(motorsHolder_.begin(), motorsHolder_.end(),
+                           std::back_inserter(motorEffortFieldnames_),
+                           [](auto const & elem) -> std::string
+                           {
+                               if (elem->getJointType() == joint_t::LINEAR)
+                               {
+                                   return addCircumfix(elem->getName(), JOINT_PREFIX_BASE + "Force");
+                               }
+                               else
+                               {
+                                   return addCircumfix(elem->getName(), JOINT_PREFIX_BASE + "Torque");
+                               }
+                           });
         }
 
         return returnCode;

--- a/data/cartpole/cartpole.urdf
+++ b/data/cartpole/cartpole.urdf
@@ -47,7 +47,7 @@
     <origin xyz="0.0 0.0 0.0"/>
     <parent link="slideBar"/>
     <child link="cart"/>
-    <limit effort="1000.0" lower="-5" upper="5" velocity="1000"/>
+    <limit effort="1000.0" velocity="100.0" lower="-5.0" upper="5.0"/>
   </joint>
 
   <link name="pole">
@@ -80,7 +80,7 @@
     <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
     <parent link="cart"/>
     <child link="pole"/>
-    <limit effort="1000.0" lower="-10" upper="10" velocity="1000"/>
+    <limit effort="1000.0" velocity="100.0" lower="-10.0" upper="10.0"/>
   </joint>
 
 </robot>

--- a/examples/double_pendulum/double_pendulum.cc
+++ b/examples/double_pendulum/double_pendulum.cc
@@ -91,7 +91,7 @@ int main(int argc, char_t * argv[])
     boost::get<bool_t>(boost::get<configHolder_t>(simuOptions.at("telemetry")).at("enableConfiguration")) = true;
     boost::get<bool_t>(boost::get<configHolder_t>(simuOptions.at("telemetry")).at("enableVelocity")) = true;
     boost::get<bool_t>(boost::get<configHolder_t>(simuOptions.at("telemetry")).at("enableAcceleration")) = true;
-    boost::get<bool_t>(boost::get<configHolder_t>(simuOptions.at("telemetry")).at("enableTorque")) = true;
+    boost::get<bool_t>(boost::get<configHolder_t>(simuOptions.at("telemetry")).at("enableEffort")) = true;
     boost::get<bool_t>(boost::get<configHolder_t>(simuOptions.at("telemetry")).at("enableEnergy")) = true;
     boost::get<vectorN_t>(boost::get<configHolder_t>(simuOptions.at("world")).at("gravity"))(2) = -9.81;
     boost::get<std::string>(boost::get<configHolder_t>(simuOptions.at("stepper")).at("odeSolver")) = std::string("runge_kutta_dopri5");

--- a/gym_jiminy/gym_jiminy/common/robots.py
+++ b/gym_jiminy/gym_jiminy/common/robots.py
@@ -91,7 +91,7 @@ class RobotJiminyEnv(core.Env):
 
         # Set the torque limits of the motors
         for motor_name in robot_options["motors"].keys():
-            robot_options["motors"][motor_name]["enableTorqueLimit"] = True
+            robot_options["motors"][motor_name]["enableEffortLimit"] = True
 
         # Configure the stepper update period and disable max number of iterations
         engine_options["stepper"]["iterMax"] = -1

--- a/gym_jiminy/gym_jiminy/envs/__init__.py
+++ b/gym_jiminy/gym_jiminy/envs/__init__.py
@@ -1,2 +1,2 @@
-from gym_jiminy.envs.cartpole import JiminyCartPoleEnv
-from gym_jiminy.envs.acrobot import JiminyAcrobotEnv, JiminyAcrobotGoalEnv
+from .cartpole import JiminyCartPoleEnv
+from .acrobot import JiminyAcrobotEnv, JiminyAcrobotGoalEnv

--- a/gym_jiminy/gym_jiminy/envs/acrobot.py
+++ b/gym_jiminy/gym_jiminy/envs/acrobot.py
@@ -115,8 +115,8 @@ class JiminyAcrobotGoalEnv(RobotJiminyGoalEnv):
         robot_options["model"]["joints"]["velocityLimit"] = MAX_VEL * np.ones(2)
 
         # Set the torque limits of the motors
-        robot_options["motors"][motor_joint_name]["torqueLimitFromUrdf"] = False
-        robot_options["motors"][motor_joint_name]["torqueLimit"] = MAX_TORQUE
+        robot_options["motors"][motor_joint_name]["effortLimitFromUrdf"] = False
+        robot_options["motors"][motor_joint_name]["effortLimit"] = MAX_TORQUE
 
         self._robot.set_options(robot_options)
 

--- a/gym_jiminy/gym_jiminy/envs/acrobot.py
+++ b/gym_jiminy/gym_jiminy/envs/acrobot.py
@@ -114,7 +114,7 @@ class JiminyAcrobotGoalEnv(RobotJiminyGoalEnv):
         robot_options["model"]["joints"]["velocityLimitFromUrdf"] = False
         robot_options["model"]["joints"]["velocityLimit"] = MAX_VEL * np.ones(2)
 
-        # Set the torque limits of the motors
+        # Set the effort limit of the motor
         robot_options["motors"][motor_joint_name]["effortLimitFromUrdf"] = False
         robot_options["motors"][motor_joint_name]["effortLimit"] = MAX_TORQUE
 

--- a/gym_jiminy/gym_jiminy/envs/cartpole.py
+++ b/gym_jiminy/gym_jiminy/envs/cartpole.py
@@ -113,7 +113,7 @@ class JiminyCartPoleEnv(RobotJiminyEnv):
 
         robot_options = self._robot.get_options()
 
-        # Set the torque limits of the motor
+        # Set the effort limit of the motor
         robot_options["motors"][motor_joint_name]["effortLimitFromUrdf"] = False
         robot_options["motors"][motor_joint_name]["effortLimit"] = MAX_FORCE
 

--- a/gym_jiminy/gym_jiminy/envs/cartpole.py
+++ b/gym_jiminy/gym_jiminy/envs/cartpole.py
@@ -114,8 +114,8 @@ class JiminyCartPoleEnv(RobotJiminyEnv):
         robot_options = self._robot.get_options()
 
         # Set the torque limits of the motor
-        robot_options["motors"][motor_joint_name]["torqueLimitFromUrdf"] = False
-        robot_options["motors"][motor_joint_name]["torqueLimit"] = MAX_FORCE
+        robot_options["motors"][motor_joint_name]["effortLimitFromUrdf"] = False
+        robot_options["motors"][motor_joint_name]["effortLimit"] = MAX_FORCE
 
         self._robot.set_options(robot_options)
 

--- a/gym_jiminy/gym_jiminy/unit/acrobot_learning/acrobot_her_baseline.py
+++ b/gym_jiminy/gym_jiminy/unit/acrobot_learning/acrobot_her_baseline.py
@@ -3,18 +3,14 @@ import time
 
 import gym
 
-from stable_baselines.her import GoalSelectionStrategy
+from stable_baselines.her import HER, GoalSelectionStrategy
 from stable_baselines.sac.policies import FeedForwardPolicy
-from stable_baselines import HER, DQN, SAC, TD3, #DDPG
+from stable_baselines import SAC
 
-import jiminy_py
-
-# Select the model class
-model_class = SAC
 
 # Create a single-process environment
 env = gym.make("gym_jiminy:jiminy-acrobot-v0",
-               continuous=model_class in [SAC, TD3],#, DDPG],
+               continuous=True,
                enableGoalEnv=True)
 
 ### Create the model or load one
@@ -25,9 +21,9 @@ class CustomPolicy(FeedForwardPolicy):
     __module__ = None
 
     def __init__(self, *args, **_kwargs):
-        super(CustomPolicy, self).__init__(*args, **_kwargs,
-                                           layers=[64, 64],
-                                           feature_extraction="mlp")
+        super().__init__(*args, **_kwargs,
+                         layers=[64, 64],
+                         feature_extraction="mlp")
 
 # Define a custom linear scheduler for the learning rate
 class LinearSchedule(object):
@@ -48,7 +44,7 @@ n_sampled_goal = 4
 tensorboard_data_path = os.path.dirname(os.path.realpath(__file__))
 
 # Create the 'model' according to the chosen algorithm
-model = HER(CustomPolicy, env, model_class,
+model = HER(CustomPolicy, env, SAC,
             n_sampled_goal=n_sampled_goal,
             goal_selection_strategy=GoalSelectionStrategy.FUTURE, buffer_size=1000000,
             learning_rate=learning_rate_scheduler.value, target_update_interval=256,

--- a/gym_jiminy/gym_jiminy/unit/acrobot_learning/acrobot_ppo2_baseline.py
+++ b/gym_jiminy/gym_jiminy/unit/acrobot_learning/acrobot_ppo2_baseline.py
@@ -2,17 +2,15 @@ import os
 import time
 
 import gym
+from gym_jiminy.common import SubprocVecEnvLock
 
-from gym.wrappers import FlattenDictWrapper
 from stable_baselines.common.policies import MlpPolicy
 from stable_baselines import PPO2
 
-import jiminy_py
-from gym_jiminy.common import SubprocVecEnvLock
 
 ### Create a multiprocess environment
-nb_cpu = 4
-env = SubprocVecEnvLock([lambda: gym.make("gym_jiminy:jiminy-acrobot-v0") for _ in range(nb_cpu)])
+n_thread = 4
+env = SubprocVecEnvLock([lambda: gym.make("gym_jiminy:jiminy-acrobot-v0") for _ in range(n_thread)])
 
 ### Create the model or load one
 

--- a/gym_jiminy/gym_jiminy/unit/cartpole_learning/cartpole_ppo2_baseline.py
+++ b/gym_jiminy/gym_jiminy/unit/cartpole_learning/cartpole_ppo2_baseline.py
@@ -2,12 +2,11 @@ import os
 import time
 
 import gym
+from gym_jiminy.common import SubprocVecEnvLock
 
 from stable_baselines.common.policies import MlpPolicy
 from stable_baselines import PPO2
 
-import jiminy_py
-from gym_jiminy.common import SubprocVecEnvLock
 
 ### Create a multiprocess environment
 n_thread = 4

--- a/gym_jiminy/setup.py
+++ b/gym_jiminy/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup, find_packages
 
 setup(name = 'gym_jiminy',
-      version = '1.2.25',
+      version = '1.2.26',
       license = 'MIT',
       description = 'Python-native interface between OpenAI Gym and Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.2.25.tar.gz',
+      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.2.26.tar.gz',
       packages = find_packages('.'),
       package_data = {'gym_jiminy.envs': ['data/**/*']},
       include_package_data = True, # make sure the data folder is included

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -30,7 +30,7 @@ setup(name = 'jiminy_py',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py': ['**/*.dll', '**/*.so', '**/*.pyd']},
-      entry_points={'console_scripts': ['jiminy_plot=jiminy_py.plotter:main']},
+      entry_points={'console_scripts': ['jiminy_plot=jiminy_py.log:plot_log']},
       include_package_data = True, # make sure the shared library is included
       distclass = BinaryDistribution,
       cmdclass = {'install': InstallPlatlib},

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -19,14 +19,14 @@ class InstallPlatlib(install):
 
 
 setup(name = 'jiminy_py',
-      version = '1.2.25',
+      version = '1.2.26',
       license = 'MIT',
       description = 'Python-native helper methods and wrapping classes for Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.2.25.tar.gz',
+      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.2.26.tar.gz',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py': ['**/*.dll', '**/*.so', '**/*.pyd']},

--- a/python/jiminy_py/src/jiminy_py/__init__.py
+++ b/python/jiminy_py/src/jiminy_py/__init__.py
@@ -1,17 +1,29 @@
-# Define the jiminy package as a site-package to enable global
-# import of Eigenpy and Pinocchio if embedded with Jiminy
-import os as _os
-import site as _site
-_site.addsitedir(_os.path.dirname(_os.path.realpath(__file__)))
+import sys as _sys
 
-# Import eigenpy and Pinocchio, then patch Pinocchio
-# to fix support of numpy.ndarray as eigen conversion
-try:
-	import eigenpy
-	import pinocchio
-	from . import _pinocchio_init as _patch
-except ImportError:
-	pass
+# Define helper to check if a module is available for compatibility with Python 2.7
+def is_package_available(pkg_name):
+    if (_sys.version_info > (3, 0)):
+        return __import__('importlib').util.find_spec(pkg_name) is not None
+    else:
+        try:
+            __import__('imp').find_module(pkg_name)
+        except ImportError:
+            return False
+        return True
+
+# Import eigenpy and Pinocchio (use the embedded version only if necessary),
+# then patch Pinocchio to fix support of numpy.ndarray as eigen conversion.
+if (is_package_available("eigenpy")):
+    import eigenpy
+else:
+    from . import eigenpy
+    _sys.modules["eigenpy"] = eigenpy
+if (is_package_available("pinocchio")):
+    import pinocchio
+else:
+    from . import pinocchio
+    _sys.modules["pinocchio"] = pinocchio
+from . import _pinocchio_init as _patch
 
 # Import core submodule
 from . import core

--- a/python/jiminy_py/src/jiminy_py/dynamics.py
+++ b/python/jiminy_py/src/jiminy_py/dynamics.py
@@ -149,7 +149,8 @@ def get_body_world_transform(robot, body_name, use_theoretical_model=True):
         pnc_model = robot.pinocchio_model
         pnc_data = robot.pinocchio_data
 
-    body_id, body_is_fixed = get_body_index_and_fixedness(robot, body_name)
+    body_id, body_is_fixed = get_body_index_and_fixedness(
+        robot, body_name, use_theoretical_model)
     if body_is_fixed:
         transform_in_parent_frame = pnc_model.frames[body_id].placement
         last_moving_parent_id = pnc_model.frames[body_id].parent
@@ -181,7 +182,8 @@ def get_body_world_velocity(robot, body_name, use_theoretical_model=True):
         pnc_model = robot.pinocchio_model
         pnc_data = robot.pinocchio_data
 
-    body_id, body_is_fixed = get_body_index_and_fixedness(robot, body_name)
+    body_id, body_is_fixed = get_body_index_and_fixedness(
+        robot, body_name, use_theoretical_model)
     if body_is_fixed:
         last_moving_parent_id = pnc_model.frames[body_id].parent
         parent_transform_in_world = pnc_data.oMi[last_moving_parent_id]
@@ -216,7 +218,8 @@ def get_body_world_acceleration(robot, body_name, use_theoretical_model=True):
         pnc_model = robot.pinocchio_model
         pnc_data = robot.pinocchio_data
 
-    body_id, body_is_fixed = get_body_index_and_fixedness(robot, body_name)
+    body_id, body_is_fixed = get_body_index_and_fixedness(
+        robot, body_name, use_theoretical_model)
 
     if body_is_fixed:
         last_moving_parent_id = pnc_model.frames[body_id].parent
@@ -269,18 +272,21 @@ def compute_freeflyer_state_from_fixed_body(robot, fixed_body_name, position,
     pnc.forwardKinematics(pnc_model, pnc_data, position, velocity, acceleration)
     pnc.framesForwardKinematics(pnc_model, pnc_data, position)
 
-    ff_M_fixed_body = get_body_world_transform(robot, fixed_body_name)
+    ff_M_fixed_body = get_body_world_transform(
+        robot, fixed_body_name, use_theoretical_model)
     w_M_ff = ff_M_fixed_body.inverse()
     base_link_translation = w_M_ff.translation
     base_link_quaternion = Quaternion(w_M_ff.rotation)
     position[:3] = base_link_translation
     position[3:7] = base_link_quaternion.coeffs()
 
-    ff_v_fixed_body = get_body_world_velocity(robot, fixed_body_name)
+    ff_v_fixed_body = get_body_world_velocity(
+        robot, fixed_body_name, use_theoretical_model)
     base_link_velocity = - ff_v_fixed_body
     velocity[:6] = base_link_velocity.vector
 
-    ff_a_fixedBody = get_body_world_acceleration(robot, fixed_body_name)
+    ff_a_fixedBody = get_body_world_acceleration(
+        robot, fixed_body_name, use_theoretical_model)
     base_link_acceleration = - ff_a_fixedBody
     acceleration[:6] = base_link_acceleration.vector
 
@@ -295,8 +301,8 @@ def retrieve_freeflyer(trajectory_data, roll_angle=0.0, pitch_angle=0.0):
         q, v, a = s.q.squeeze(), s.v.squeeze(), s.a.squeeze()
 
         # Compute freeflyer using support foot as reference frame.
-        compute_freeflyer_state_from_fixed_body(robot, s.support_foot,
-                                           q, v, a, use_theoretical_model)
+        compute_freeflyer_state_from_fixed_body(
+            robot, s.support_foot, q, v, a, use_theoretical_model)
 
         # Move freeflyer to take the foot angle into account.
         # w: world frame, st: support foot frame, ff: freeflyer frame.

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -104,7 +104,7 @@ def plot_log():
         "Example: h1 h2:h3:h4 generates two subplots, one with h1, one with h2, h3, and h4.\n" + \
         "Wildcard token '*' can be used. In such a case:\n" + \
         "- If *h2* matches several fields : each field will be plotted individually in subplots. \n" + \
-        "- If :*h2* matches several fields : each field will be plotted in the same subplot. \n" + \
+        "- If :*h2* or :*h2*:*h3*:*h4* matches several fields : each field will be plotted in the same subplot. \n" + \
         "- If *h2*:*h3*:*h4* matches several fields : each match of h2, h3, and h4 will be plotted jointly in subplots.\n" + \
         "  Note that if the number of matches for h2, h3, h4 differs, only the minimum number will be plotted.\n" + \
         "\nEnter no plot command (only the file name) to view the list of fields available inside the file."
@@ -130,20 +130,21 @@ def plot_log():
         same_subplot = (cmd[0] == ':')
         headers = cmd.strip(':').split(':')
 
-        # Expand each element according to a regular expression.
+        # Expand each element if wildcard tokens are present.
         matching_headers = []
         for h in headers:
             matching_headers.append(sorted(fnmatch.filter(log_data.keys(), h)))
 
         # Get minimum size for number of subplots.
-        n_subplots = min([len(l) for l in matching_headers])
-        for i in range(n_subplots):
-            plotted_elements.append([l[i] for l in matching_headers])
+        if same_subplot:
+            plotted_elements.append([e for l_sub in matching_headers for e in l_sub])
+        else:
+            n_subplots = min([len(l) for l in matching_headers])
+            for i in range(n_subplots):
+                plotted_elements.append([l[i] for l in matching_headers])
 
     # Create figure.
     n_plot = len(plotted_elements)
-
-    print(plotted_elements)
 
     # Arrange plot in rectangular fashion: don't allow for n_cols to be more than n_rows + 2
     n_cols = n_plot

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -100,12 +100,18 @@ def read_log(filename):
 def plot_log():
     description_str = \
         "Plot data from a jiminy log file using matplotlib.\n" + \
-        "Simply specify a list of fields to plot, separated by a colon for plotting on the same subplot.\n" +\
-        "Example: h1 h2:h3 generates two subplots, one with h1, one with h2 and h3.\n" + \
-        "Regular expressions can be used. Enter no plot command (only the file name) to view the list of fields available inside the file."
+        "Specify a list of fields to plot, separated by a colon for plotting on the same subplot.\n\n" + \
+        "Example: h1 h2:h3:h4 generates two subplots, one with h1, one with h2, h3, and h4.\n" + \
+        "Wildcard token '*' can be used. In such a case:\n" + \
+        "- If *h2* matches several fields : each field will be plotted individually in subplots. \n" + \
+        "- If :*h2* matches several fields : each field will be plotted in the same subplot. \n" + \
+        "- If *h2*:*h3*:*h4* matches several fields : each match of h2, h3, and h4 will be plotted jointly in subplots.\n" + \
+        "  Note that if the number of matches for h2, h3, h4 differs, only the minimum number will be plotted.\n" + \
+        "\nEnter no plot command (only the file name) to view the list of fields available inside the file."
 
-    parser = argparse.ArgumentParser(description = description_str, formatter_class = argparse.RawTextHelpFormatter)
-    parser.add_argument("input", help = "Input logfile.")
+    parser = argparse.ArgumentParser(description=description_str,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("input", help="Input logfile.")
     main_arguments, plotting_commands = parser.parse_known_args()
 
     # Load log file.
@@ -121,7 +127,8 @@ def plot_log():
     plotted_elements = []
     for cmd in plotting_commands:
         # Check that the command is valid, i.e. that all elements exits. If it is the case, add it to the list.
-        headers = cmd.split(":")
+        same_subplot = (cmd[0] == ':')
+        headers = cmd.strip(':').split(':')
 
         # Expand each element according to a regular expression.
         matching_headers = []
@@ -136,15 +143,16 @@ def plot_log():
     # Create figure.
     n_plot = len(plotted_elements)
 
+    print(plotted_elements)
+
     # Arrange plot in rectangular fashion: don't allow for n_cols to be more than n_rows + 2
     n_cols = n_plot
     n_rows = 1
     while n_cols > n_rows + 2:
         n_rows = n_rows + 1
-        n_cols = int(np.ceil(n_plot / (1.0 * n_rows)))
+        n_cols = int(np.ceil(n_plot / float(n_rows)))
 
     _, axs = plt.subplots(nrows=n_rows, ncols=n_cols, sharex = True)
-
     if n_plot == 1:
         axs = np.array([axs])
     axs = axs.flatten()

--- a/python/jiminy_py/src/jiminy_py/state.py
+++ b/python/jiminy_py/src/jiminy_py/state.py
@@ -23,7 +23,7 @@ class State:
         @param[in]  f       Forces on the different bodies of the robot. Dictionary whose keys represent
                             a given foot orientation. For each orientation, a dictionary contains the
                             6D-force for each body (1D numpy array).
-        @param[in]  tau     Joint torques. Dictionary whose keys represent a given foot orientation.
+        @param[in]  tau     Joint efforts. Dictionary whose keys represent a given foot orientation.
         @param[in]  f_ext   External forces represented in the frame of the Henke ankle. Dictionary
                             whose keys represent a given foot orientation.
 
@@ -41,7 +41,7 @@ class State:
         self.f = {}
         if f is not None:
             self.f = deepcopy(f)
-        ## Torque vector
+        ## Effort vector
         self.tau = {}
         if tau is not None:
             self.tau = deepcopy(tau)

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -372,9 +372,7 @@ class Viewer:
         @brief      Get the full path of a node associated with a given geometry
                     object and geometry type.
 
-        @remark     This is a hidden function that is not automatically imported
-                    using 'from wdc_jiminy_py import *'. It is not intended to
-                    be called manually.
+        @remark     This is a hidden function not intended to be called manually.
 
         @param[in]  geometry_object     Geometry object from which to get the node
         @param[in]  geometry_type       Geometry type. It must be either
@@ -392,9 +390,7 @@ class Viewer:
         """
         @brief      Update the generalized position of a geometry object.
 
-        @remark     This is a hidden function that is not automatically imported
-                    using 'from wdc_jiminy_py import *'. It is not intended to
-                    be called manually.
+        @remark     This is a hidden function not intended to be called manually.
 
         @param[in]  visual      Wether it is a visual or collision update
         """
@@ -506,10 +502,12 @@ def play_trajectories(trajectory_data, mesh_root_path = None, xyz_offset=None, u
                       start_paused=False, backend=None, window_name='python-pinocchio', scene_name='world',
                       close_backend=None):
     """!
-    @brief      Display robot evolution in choosen viewer (gepetto-gui or meshcat) at stable speed.
+    @brief      Display a robot trajectory in a viewer.
 
-    @remark     The speed is independent of the machine, and more
-                specifically of CPU power.
+    @details    The ratio between the replay and the simulation time is kept constant to the desired ratio.
+                One can choose between several backend (gepetto-gui or meshcat).
+
+    @remark     The speed is independent of the plateform and the CPU power.
 
     @param[in]  trajectory_data     Trajectory dictionary with keys:
                                     'evolution_robot': list of State object of increasing time

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -115,7 +115,16 @@ class Viewer:
 
         # Check if the backend is still available, if any
         if Viewer._backend_obj is not None and Viewer._backend_proc is not None:
+            is_backend_running = True
             if Viewer._backend_proc.poll() is not None:
+                is_backend_running = False
+            if (Viewer.backend == 'gepetto-gui'):
+                from omniORB.CORBA import TRANSIENT as gepetto_server_error
+                try:
+                    Viewer._backend_obj.gui.refresh()
+                except gepetto_server_error:
+                    is_backend_running = False
+            if not is_backend_running:
                 Viewer._backend_obj = None
                 Viewer._backend_proc = None
                 Viewer._backend_exception = None

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -59,7 +59,7 @@ class Viewer:
     _backend_exception = None
     _backend_proc = None
     ## Unique threading.Lock for every simulation.
-    # It is required for parallel rendering since corbaserver does not support multiple connection simultaneously.
+    #  It is required for parallel rendering since some backends may not support multiple connection simultaneously (e.g. corbasever).
     _lock = Lock()
 
     def __init__(self, robot, use_theoretical_model=False,

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -920,11 +920,11 @@ namespace python
                 .add_property("flexible_joints_names", bp::make_function(&Model::getFlexibleJointsNames,
                                                        bp::return_value_policy<bp::copy_const_reference>()))
 
-                .add_property("joints_position_limit_upper", bp::make_function(&Model::getJointsPositionLimitMin,
+                .add_property("position_limit_upper", bp::make_function(&Model::getPositionLimitMin,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("joints_position_limit_lower", bp::make_function(&Model::getJointsPositionLimitMax,
+                .add_property("position_limit_lower", bp::make_function(&Model::getPositionLimitMax,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("joints_velocity_limit", bp::make_function(&Model::getJointsVelocityLimit,
+                .add_property("velocity_limit", bp::make_function(&Model::getVelocityLimit,
                                                 bp::return_value_policy<bp::copy_const_reference>()))
 
                 .add_property("logfile_position_headers", bp::make_function(&Model::getPositionFieldnames,

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -579,6 +579,8 @@ namespace python
                                                 bp::return_value_policy<bp::copy_const_reference>()))
                     .add_property("joint_idx", bp::make_function(&AbstractMotorBase::getJointModelIdx,
                                                bp::return_value_policy<bp::copy_const_reference>()))
+                    .add_property("joint_type", bp::make_function(&AbstractMotorBase::getJointType,
+                                                bp::return_value_policy<bp::copy_const_reference>()))
                     .add_property("joint_position_idx", bp::make_function(&AbstractMotorBase::getJointPositionIdx,
                                                         bp::return_value_policy<bp::copy_const_reference>()))
                     .add_property("joint_velocity_idx", bp::make_function(&AbstractMotorBase::getJointVelocityIdx,

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -829,73 +829,73 @@ namespace python
                 .def("get_rigid_state_from_flexible", &PyModelVisitor::getRigidStateFromFlexible,
                                                       (bp::arg("self"), "flexible_state"))
 
-                .add_property("pinocchio_model", bp::make_getter(&Robot::pncModel_,
+                .add_property("pinocchio_model", bp::make_getter(&Model::pncModel_,
                                                  bp::return_internal_reference<>()))
-                .add_property("pinocchio_data", bp::make_getter(&Robot::pncData_,
+                .add_property("pinocchio_data", bp::make_getter(&Model::pncData_,
                                                 bp::return_internal_reference<>()))
-                .add_property("pinocchio_model_th", bp::make_getter(&Robot::pncModelRigidOrig_,
+                .add_property("pinocchio_model_th", bp::make_getter(&Model::pncModelRigidOrig_,
                                                     bp::return_internal_reference<>()))
-                .add_property("pinocchio_data_th", bp::make_getter(&Robot::pncDataRigidOrig_,
+                .add_property("pinocchio_data_th", bp::make_getter(&Model::pncDataRigidOrig_,
                                                    bp::return_internal_reference<>()))
 
-                .add_property("is_initialized", bp::make_function(&Robot::getIsInitialized,
+                .add_property("is_initialized", bp::make_function(&Model::getIsInitialized,
                                                 bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("urdf_path", bp::make_function(&Robot::getUrdfPath,
+                .add_property("urdf_path", bp::make_function(&Model::getUrdfPath,
                                            bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("has_freeflyer", bp::make_function(&Robot::getHasFreeflyer,
+                .add_property("has_freeflyer", bp::make_function(&Model::getHasFreeflyer,
                                                bp::return_value_policy<bp::copy_const_reference>()))
                 .add_property("is_flexible", &PyModelVisitor::isFlexibleModelEnable)
-                .add_property("nq", bp::make_function(&Robot::nq,
+                .add_property("nq", bp::make_function(&Model::nq,
                                     bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("nv", bp::make_function(&Robot::nv,
+                .add_property("nv", bp::make_function(&Model::nv,
                                     bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("nx", bp::make_function(&Robot::nx,
+                .add_property("nx", bp::make_function(&Model::nx,
                                     bp::return_value_policy<bp::copy_const_reference>()))
 
-                .add_property("contact_frames_names", bp::make_function(&Robot::getContactFramesNames,
+                .add_property("contact_frames_names", bp::make_function(&Model::getContactFramesNames,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("contact_frames_idx", bp::make_function(&Robot::getContactFramesIdx,
+                .add_property("contact_frames_idx", bp::make_function(&Model::getContactFramesIdx,
                                                     bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("rigid_joints_names", bp::make_function(&Robot::getRigidJointsNames,
+                .add_property("rigid_joints_names", bp::make_function(&Model::getRigidJointsNames,
                                                     bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("rigid_joints_position_idx", bp::make_function(&Robot::getRigidJointsPositionIdx,
+                .add_property("rigid_joints_position_idx", bp::make_function(&Model::getRigidJointsPositionIdx,
                                                            bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("rigid_joints_velocity_idx", bp::make_function(&Robot::getRigidJointsVelocityIdx,
+                .add_property("rigid_joints_velocity_idx", bp::make_function(&Model::getRigidJointsVelocityIdx,
                                                            bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("flexible_joints_names", bp::make_function(&Robot::getFlexibleJointsNames,
+                .add_property("flexible_joints_names", bp::make_function(&Model::getFlexibleJointsNames,
                                                        bp::return_value_policy<bp::copy_const_reference>()))
 
-                .add_property("position_limit_upper", bp::make_function(&Robot::getPositionLimitMin,
+                .add_property("position_limit_upper", bp::make_function(&Model::getPositionLimitMin,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("position_limit_lower", bp::make_function(&Robot::getPositionLimitMax,
+                .add_property("position_limit_lower", bp::make_function(&Model::getPositionLimitMax,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("velocity_limit", bp::make_function(&Robot::getVelocityLimit,
+                .add_property("velocity_limit", bp::make_function(&Model::getVelocityLimit,
                                                 bp::return_value_policy<bp::copy_const_reference>()))
 
-                .add_property("logfile_position_headers", bp::make_function(&Robot::getPositionFieldnames,
+                .add_property("logfile_position_headers", bp::make_function(&Model::getPositionFieldnames,
                                                           bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("logfile_velocity_headers", bp::make_function(&Robot::getVelocityFieldnames,
+                .add_property("logfile_velocity_headers", bp::make_function(&Model::getVelocityFieldnames,
                                                           bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("logfile_acceleration_headers", bp::make_function(&Robot::getAccelerationFieldnames,
+                .add_property("logfile_acceleration_headers", bp::make_function(&Model::getAccelerationFieldnames,
                                                               bp::return_value_policy<bp::copy_const_reference>()))
                 ;
         }
 
-        static hresult_t addContactPoints(Robot          & self,
+        static hresult_t addContactPoints(Model          & self,
                                           bp::list const & frameNamesPy)
         {
             auto frameNames = convertFromPython<std::vector<std::string> >(frameNamesPy);
             return self.addContactPoints(frameNames);
         }
 
-        static hresult_t removeContactPoints(Robot          & self,
+        static hresult_t removeContactPoints(Model          & self,
                                              bp::list const & frameNamesPy)
         {
             auto frameNames = convertFromPython<std::vector<std::string> >(frameNamesPy);
             return self.removeContactPoints(frameNames);
         }
 
-        static vectorN_t getFlexibleStateFromRigid(Robot           & self,
+        static vectorN_t getFlexibleStateFromRigid(Model           & self,
                                                    vectorN_t const & xRigid)
         {
             vectorN_t xFlexible;
@@ -903,7 +903,7 @@ namespace python
             return xFlexible;
         }
 
-        static vectorN_t getRigidStateFromFlexible(Robot           & self,
+        static vectorN_t getRigidStateFromFlexible(Model           & self,
                                                    vectorN_t const & xFlexible)
         {
             vectorN_t xRigid;
@@ -915,7 +915,7 @@ namespace python
         /// \brief      Getters and Setters
         ///////////////////////////////////////////////////////////////////////////////
 
-        static bool_t isFlexibleModelEnable(Robot & self)
+        static bool_t isFlexibleModelEnable(Model & self)
         {
             return self.mdlOptions_->dynamics.enableFlexibleModel;
         }

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -918,11 +918,11 @@ namespace python
                 .add_property("flexible_joints_names", bp::make_function(&Model::getFlexibleJointsNames,
                                                        bp::return_value_policy<bp::copy_const_reference>()))
 
-                .add_property("position_limit_upper", bp::make_function(&Model::getPositionLimitMin,
+                .add_property("joints_position_limit_upper", bp::make_function(&Model::getJointsPositionLimitMin,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("position_limit_lower", bp::make_function(&Model::getPositionLimitMax,
+                .add_property("joints_position_limit_lower", bp::make_function(&Model::getJointsPositionLimitMax,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("velocity_limit", bp::make_function(&Model::getVelocityLimit,
+                .add_property("joints_velocity_limit", bp::make_function(&Model::getJointsVelocityLimit,
                                                 bp::return_value_policy<bp::copy_const_reference>()))
 
                 .add_property("logfile_position_headers", bp::make_function(&Model::getPositionFieldnames,

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -583,7 +583,7 @@ namespace python
                                                         bp::return_value_policy<bp::copy_const_reference>()))
                     .add_property("joint_velocity_idx", bp::make_function(&AbstractMotorBase::getJointVelocityIdx,
                                                         bp::return_value_policy<bp::copy_const_reference>()))
-                    .add_property("torque_limit", bp::make_function(&AbstractMotorBase::getTorqueLimit,
+                    .add_property("effort_limit", bp::make_function(&AbstractMotorBase::getEffortLimit,
                                                   bp::return_value_policy<bp::copy_const_reference>()))
                     .add_property("rotor_inertia", bp::make_function(&AbstractMotorBase::getRotorInertia,
                                                    bp::return_value_policy<bp::copy_const_reference>()))
@@ -791,16 +791,16 @@ namespace python
             }
 
             template<class Q = TSensor>
-            static enable_if_t<std::is_same<Q, TorqueSensor>::value, void>
+            static enable_if_t<std::is_same<Q, EffortSensor>::value, void>
             visit(PyClass& cl)
             {
                 visitAbstract(cl);
                 visitBasicSensors(cl);
 
                 cl
-                    .add_property("motor_name", bp::make_function(&TorqueSensor::getMotorName,
+                    .add_property("motor_name", bp::make_function(&EffortSensor::getMotorName,
                                                 bp::return_value_policy<bp::copy_const_reference>()))
-                    .add_property("motor_idx", bp::make_function(&TorqueSensor::getMotorIdx,
+                    .add_property("motor_idx", bp::make_function(&EffortSensor::getMotorIdx,
                                                bp::return_value_policy<bp::copy_const_reference>()))
                     ;
             }
@@ -851,9 +851,9 @@ namespace python
                        boost::noncopyable>("EncoderSensor", bp::init<std::string>())
                 .def(PySensorVisitor());
 
-            bp::class_<TorqueSensor, bp::bases<AbstractSensorBase>,
-                       std::shared_ptr<TorqueSensor>,
-                       boost::noncopyable>("TorqueSensor", bp::init<std::string>())
+            bp::class_<EffortSensor, bp::bases<AbstractSensorBase>,
+                       std::shared_ptr<EffortSensor>,
+                       boost::noncopyable>("EffortSensor", bp::init<std::string>())
                 .def(PySensorVisitor());
         }
     };
@@ -1052,10 +1052,10 @@ namespace python
                 .add_property("motors_velocity_idx", &Robot::getMotorsVelocityIdx)
                 .add_property("sensors_names", &PyRobotVisitor::getSensorsNames)
 
-                .add_property("torque_limit", &Robot::getTorqueLimit)
+                .add_property("effort_limit", &Robot::getEffortLimit)
                 .add_property("motor_inertia", &Robot::getMotorInertia)
 
-                .add_property("logfile_motor_torque_headers", bp::make_function(&Robot::getMotorTorqueFieldnames,
+                .add_property("logfile_motor_effort_headers", bp::make_function(&Robot::getMotorEffortFieldnames,
                                                               bp::return_value_policy<bp::copy_const_reference>()))
                 ;
         }

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -920,9 +920,9 @@ namespace python
                 .add_property("flexible_joints_names", bp::make_function(&Model::getFlexibleJointsNames,
                                                        bp::return_value_policy<bp::copy_const_reference>()))
 
-                .add_property("position_limit_upper", bp::make_function(&Model::getPositionLimitMin,
+                .add_property("position_limit_lower", bp::make_function(&Model::getPositionLimitMin,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
-                .add_property("position_limit_lower", bp::make_function(&Model::getPositionLimitMax,
+                .add_property("position_limit_upper", bp::make_function(&Model::getPositionLimitMax,
                                                       bp::return_value_policy<bp::copy_const_reference>()))
                 .add_property("velocity_limit", bp::make_function(&Model::getVelocityLimit,
                                                 bp::return_value_policy<bp::copy_const_reference>()))

--- a/python/jiminy_pywrap/src/Module.cc
+++ b/python/jiminy_pywrap/src/Module.cc
@@ -80,6 +80,15 @@ namespace python
         .value("ERROR_BAD_INPUT",   hresult_t::ERROR_BAD_INPUT)
         .value("ERROR_INIT_FAILED", hresult_t::ERROR_INIT_FAILED);
 
+        // Interfaces for joint_t enum
+        bp::enum_<joint_t>("joint_t")
+        .value("NONE",      joint_t::NONE)
+        .value("LINEAR",    joint_t::LINEAR)
+        .value("ROTARY",    joint_t::ROTARY)
+        .value("PLANAR",    joint_t::PLANAR)
+        .value("SPHERICAL", joint_t::SPHERICAL)
+        .value("FREE",      joint_t::FREE);
+
         // Interfaces for heatMapType_t enum
         bp::enum_<heatMapType_t>("heatMapType_t")
         .value("CONSTANT", heatMapType_t::CONSTANT)

--- a/unit/EngineSanityCheck.cc
+++ b/unit/EngineSanityCheck.cc
@@ -49,7 +49,7 @@ TEST(EngineSanity, EnergyConservation)
     // Double pendulum model
     std::string const dataDirPath(UNIT_TEST_DATA_DIR);
     auto const urdfPath = dataDirPath + "/double_pendulum_rigid.urdf";
-    
+
     // All joints actuated.
     std::vector<std::string> motorJointNames{"PendulumJoint", "SecondPendulumJoint"};
 
@@ -73,7 +73,7 @@ TEST(EngineSanity, EnergyConservation)
     for (auto & options : motorsOptions)
     {
         configHolder_t & motorOptions = boost::get<configHolder_t>(options.second);
-        boost::get<bool_t>(motorOptions.at("enableTorqueLimit")) = false;
+        boost::get<bool_t>(motorOptions.at("enableEffortLimit")) = false;
     }
     robot->setMotorsOptions(motorsOptions);
 

--- a/unit_py/utilities.py
+++ b/unit_py/utilities.py
@@ -32,7 +32,7 @@ def load_urdf_default(urdf_path, motor_names, has_freeflyer = False):
     model_options["joints"]["enablePositionLimit"] = False
     model_options["joints"]["enableVelocityLimit"] = False
     for m in motor_options:
-        motor_options[m]['enableTorqueLimit'] = False
+        motor_options[m]['enableEffortLimit'] = False
         motor_options[m]['enableRotorInertia'] = False
     robot.set_model_options(model_options)
     robot.set_motors_options(motor_options)


### PR DESCRIPTION
- [jiminy core] Add jointType attribute to the motor. Only support linear and rotary joints for motors.
- [jiminy core] Replace Torque by Effort to be appropriate for both rotary and linear joints.
- [jiminy core] Add prefix 'joints' to the ambiguous fields (Position|Velocity)Limit*.
- [jiminy core] Define more appropriate position/velocity/effort limits for non-physical joints.

____

- [jiminy_py C++] Improve pinocchio/eigenpy 'submodule' management.
- [jiminy_py C++] Add getters and expose sensor type specific properties. Fix wrong exposure of the sensors names.
- [jiminy_py C++] Fix Robot class used instead of Model in Jiminy bindings.

____

- [jiminy_py Python] Improve robustness of viewer to handle closed gepetto-gui during rendering.
- [jiminy_py Python] Enable to render the initial state of EngineAsynchronous.

____

- [gym_jiminy] Refactoring of Gym Jiminy to extract more information from the model instead of using hardcoded values.
-  [gym_jiminy] The observation space now corresponds to the sensors and state spaces by default.
-  [gym_jiminy] Use Global variable to define "universal bounds" to overwrite jiminy inf bounds if desired. 

____

- [jiminy_plot] Move plotter.py in log.py since they are related. Remove Python3 only typing.
- [jiminy_plot] Prepend expressions with ':' enable to plot every matched fields in the same subplot.

For example
```
jiminy_plot /tmp/traj.data :*.FX:*.FY:*.FZ :*.Q :*.V *energy
```

![image](https://user-images.githubusercontent.com/17752950/79778074-7a362f00-8338-11ea-901c-8a459d8faa6e.png)
____

- [doc] Update readme.
