### PR TITLE
[jiminy_py] Add option for plotter to compare several logfiles.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.2.30)
+set(BUILD_VERSION 1.2.31)
 
 # Add definition of Jiminy version for C++ headers
 add_definitions("-DJIMINY_VERSION=\"${BUILD_VERSION}\"")

--- a/build_tools/cmake/base.cmake
+++ b/build_tools/cmake/base.cmake
@@ -190,7 +190,7 @@ if(BUILD_PYTHON_INTERFACE)
     # Define Python install helpers
     function(deployPythonPackage TARGET_NAME)
         install(CODE "execute_process(COMMAND pip install ${PYTHON_INSTALL_FLAGS} .
-                                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pypi/${TARGET_NAME})")
+                                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pypi/${TARGET_NAME})")
     endfunction()
 
     function(deployPythonPackageDevelop TARGET_NAME)

--- a/build_tools/cmake/buildPythonWheel.cmake
+++ b/build_tools/cmake/buildPythonWheel.cmake
@@ -1,7 +1,10 @@
 function(buildPythonWheel TARGET_PATH)
     get_filename_component(TARGET_NAME ${TARGET_PATH} NAME_WE)
     get_filename_component(TARGET_DIR ${TARGET_PATH} DIRECTORY)
-    install(CODE "file(GLOB_RECURSE src_file_list FOLLOW_SYMLINKS
+    install(CODE "cmake_policy(SET CMP0053 NEW)
+                  cmake_policy(SET CMP0011 NEW)
+                  set(PROJECT_VERSION ${BUILD_VERSION})
+                  file(GLOB_RECURSE src_file_list FOLLOW_SYMLINKS
                        LIST_DIRECTORIES false
                        RELATIVE \"${CMAKE_SOURCE_DIR}/${TARGET_DIR}\"
                        \"${CMAKE_SOURCE_DIR}/${TARGET_PATH}/*\"
@@ -11,8 +14,8 @@ function(buildPythonWheel TARGET_PATH)
                   foreach(src_file \${src_file_list})
                       get_filename_component(src_file_real \"\${src_file}\" REALPATH
                                              BASE_DIR \"${CMAKE_SOURCE_DIR}/${TARGET_DIR}\")
-                      file(COPY \"\${src_file_real}/\"
-                           DESTINATION \"${CMAKE_BINARY_DIR}/pypi/\${src_file}\")
+                      configure_file(\"\${src_file_real}\"
+                                     \"${CMAKE_BINARY_DIR}/pypi/\${src_file}\" @ONLY)
                   endforeach()"
            )
 

--- a/core/src/robot/FixedFrameConstraint.cc
+++ b/core/src/robot/FixedFrameConstraint.cc
@@ -68,6 +68,8 @@ namespace jiminy
 
     hresult_t FixedFrameConstraint::refreshProxies()
     {
+        // Resize the jacobian to the model dimension.
+        jacobian_.resize(6, model_->pncModel_.nv);
         return getFrameIdx(model_->pncModel_, frameName_, frameIdx_);
     }
 }

--- a/gym_jiminy/setup.py
+++ b/gym_jiminy/setup.py
@@ -1,14 +1,15 @@
 from setuptools import setup, find_packages
 
+version = '1.2.31'
 setup(name = 'gym_jiminy',
-      version = '1.2.30',
+      version = version,
       license = 'MIT',
       description = 'Python-native interface between OpenAI Gym and Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.2.30.tar.gz',
+      download_url = f'https://github.com/Wandercraft/jiminy/archive/{version}.tar.gz',
       packages = find_packages('.'),
       package_data = {'gym_jiminy.envs': ['data/**/*']},
       include_package_data = True, # make sure the data folder is included

--- a/gym_jiminy/setup.py
+++ b/gym_jiminy/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 
-version = '1.2.31'
+
+version = __import__('jiminy_py').__version__
 setup(name = 'gym_jiminy',
       version = version,
       license = 'MIT',

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -17,16 +17,15 @@ class InstallPlatlib(install):
         if self.distribution.has_ext_modules():
             self.install_lib = self.install_platlib
 
-version = '1.2.31'
 setup(name = 'jiminy_py',
-      version = version,
+      version = '@PROJECT_VERSION@',
       license = 'MIT',
       description = 'Python-native helper methods and wrapping classes for Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = f'https://github.com/Wandercraft/jiminy/archive/{version}.tar.gz',
+      download_url = 'https://github.com/Wandercraft/jiminy/archive/@PROJECT_VERSION@.tar.gz',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py': ['**/*.dll', '**/*.so', '**/*.pyd']},

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -17,16 +17,16 @@ class InstallPlatlib(install):
         if self.distribution.has_ext_modules():
             self.install_lib = self.install_platlib
 
-
+version = '1.2.31'
 setup(name = 'jiminy_py',
-      version = '1.2.30',
+      version = version,
       license = 'MIT',
       description = 'Python-native helper methods and wrapping classes for Jiminy open-source simulator.',
       author = 'Alexis Duburcq',
       author_email = 'alexis.duburcq@wandercraft.eu',
       maintainer = 'Wandercraft',
       url = 'https://github.com/Wandercraft/jiminy',
-      download_url = 'https://github.com/Wandercraft/jiminy/archive/1.2.30.tar.gz',
+      download_url = f'https://github.com/Wandercraft/jiminy/archive/{version}.tar.gz',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py': ['**/*.dll', '**/*.so', '**/*.pyd']},

--- a/python/jiminy_py/src/jiminy_py/__init__.py
+++ b/python/jiminy_py/src/jiminy_py/__init__.py
@@ -27,3 +27,4 @@ from . import _pinocchio_init as _patch
 
 # Import core submodule
 from . import core
+from .core import __version__, __raw_version__

--- a/python/jiminy_py/src/jiminy_py/plotter.py
+++ b/python/jiminy_py/src/jiminy_py/plotter.py
@@ -21,7 +21,8 @@ def main():
     parser.add_argument("input", help = "Input logfile.")
     parser.add_argument("-c", "--compare", type=str, default=None, help = "Colon-separated list of comparison log files:" +\
         " the same data as the original log will be plotted in the same subplot, with different line styes."+ \
-        " These logfiles must be of the same length and contain the same header as the original log file")
+        " These logfiles must be of the same length and contain the same header as the original log file.\n" +\
+        " Note: you can click on the figure top legend to show / hide data from specific files.")
     main_arguments, plotting_commands = parser.parse_known_args()
 
     # Load log file.
@@ -71,15 +72,25 @@ def main():
         axs = np.array([axs])
     axs = axs.flatten()
 
+    # Store lines in dictionnary fine_name -> plotted lines, to toggle visibility.
+    main_name = os.path.basename(main_arguments.input)
+    plotted_lines = {main_name : []}
+    for c in compare_data:
+        plotted_lines[os.path.basename(c)] = []
+
     plt.gcf().canvas.set_window_title(main_arguments.input)
     t = log_data['Global.Time']
     # Plot each element.
     for i in range(n_plot):
         for name in plotted_elements[i]:
             line = axs[i].plot(t, log_data[name], label = name)
+            plotted_lines[main_name].append(line[0])
+
             linecycler = cycle(linestyles)
             for c in compare_data:
-                axs[i].plot(t, compare_data[c][name], next(linecycler), color=line[0].get_color())
+                l = axs[i].plot(t, compare_data[c][name], next(linecycler), color=line[0].get_color())
+                plotted_lines[os.path.basename(c)].append(l[0])
+
     # Add legend and grid for each plot.
     for ax in axs:
         ax.set_xlabel('time (s)')
@@ -90,16 +101,34 @@ def main():
     plt.subplots_adjust(bottom=0.05, top=0.98, left=0.06, right=0.98, wspace=0.1, hspace=0.05)
     if len(compare_data) > 0:
         linecycler = cycle(linestyles)
-        legend_lines = [Line2D([0], [0], color='k')] +\
-                       [Line2D([0], [0],  color='k', linestyle=next(linecycler)) for _ in compare_data]
-        labels = [os.path.basename(main_arguments.input)] +\
-                 [os.path.basename(c) for c in compare_data]
 
-        legend = fig.legend(legend_lines, labels, loc = 'upper center', ncol = 3)
+        # Dictionnary: line in legend to log name.
+        legend_lines = {Line2D([0], [0], color='k') : main_name}
+        for c in compare_data:
+            legend_lines[Line2D([0], [0],  color='k', linestyle=next(linecycler))] = os.path.basename(c)
+
+        legend = fig.legend(legend_lines.keys(), legend_lines.values(), loc = 'upper center', ncol = 3)
+        # Create a map (picker) -> (log name) for both the lines and the legend text.
+        picker_to_name = {}
+        for legline, name in zip(legend.get_lines(), legend_lines.values()):
+            legline.set_picker(10)  # 10 pts tolerance
+            picker_to_name[legline] = name
+        for legline, name in zip(legend.get_texts(), legend_lines.values()):
+            legline.set_picker(10)  # 10 pts tolerance
+            picker_to_name[legline] = name
+
         # Increase top margin to fit legend
         fig.canvas.draw()
         legend_height = legend.get_window_extent().inverse_transformed(fig.transFigure).height
         plt.subplots_adjust(top = 0.98 - legend_height)
+
+        def legend_clicked(event):
+            file_name = picker_to_name[event.artist]
+            for line in plotted_lines[file_name]:
+                line.set_visible(not line.get_visible())
+            fig.canvas.draw()
+        # Make legend interactive
+        fig.canvas.mpl_connect('pick_event', legend_clicked)
     plt.show()
 
 if __name__ == "__main__":

--- a/python/jiminy_py/src/jiminy_py/plotter.py
+++ b/python/jiminy_py/src/jiminy_py/plotter.py
@@ -3,7 +3,11 @@
 import argparse
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+from collections import OrderedDict
+from itertools import cycle
 import fnmatch
+import os
 
 from jiminy_py.log import read_log
 
@@ -15,6 +19,9 @@ def main():
 
     parser = argparse.ArgumentParser(description = description_str, formatter_class = argparse.RawTextHelpFormatter)
     parser.add_argument("input", help = "Input logfile.")
+    parser.add_argument("-c", "--compare", type=str, default=None, help = "Colon-separated list of comparison log files:" +\
+        " the same data as the original log will be plotted in the same subplot, with different line styes."+ \
+        " These logfiles must be of the same length and contain the same header as the original log file")
     main_arguments, plotting_commands = parser.parse_known_args()
 
     # Load log file.
@@ -25,6 +32,14 @@ def main():
         print("Available data:")
         print("\n - ".join(log_data.keys()))
         exit(0)
+
+    # Load comparision logs, if any.
+    compare_data = OrderedDict()
+    if main_arguments.compare is not None:
+        for filename in main_arguments.compare.split(':'):
+            compare_data[filename], _ = read_log(filename)
+    # Define linestyle cycle that will be used for comparison logs.
+    linestyles = ["--","-.",":"]
 
     # Parse plotting arguments.
     plotted_elements = []
@@ -50,7 +65,7 @@ def main():
         n_rows = n_rows + 1
         n_cols = np.ceil(n_plot / (1.0 * n_rows))
 
-    _, axs = plt.subplots(nrows=int(n_rows), ncols=int(n_cols), sharex = True)
+    fig, axs = plt.subplots(nrows=int(n_rows), ncols=int(n_cols), sharex = True)
 
     if n_plot == 1:
         axs = np.array([axs])
@@ -61,13 +76,30 @@ def main():
     # Plot each element.
     for i in range(n_plot):
         for name in plotted_elements[i]:
-            axs[i].plot(t, log_data[name], label = name)
-    # Add legend and grid.
+            line = axs[i].plot(t, log_data[name], label = name)
+            linecycler = cycle(linestyles)
+            for c in compare_data:
+                axs[i].plot(t, compare_data[c][name], next(linecycler), color=line[0].get_color())
+    # Add legend and grid for each plot.
     for ax in axs:
         ax.set_xlabel('time (s)')
         ax.legend()
         ax.grid()
+
+    # If a compare plot is present, add overall legend specifying line types.
     plt.subplots_adjust(bottom=0.05, top=0.98, left=0.06, right=0.98, wspace=0.1, hspace=0.05)
+    if len(compare_data) > 0:
+        linecycler = cycle(linestyles)
+        legend_lines = [Line2D([0], [0], color='k')] +\
+                       [Line2D([0], [0],  color='k', linestyle=next(linecycler)) for _ in compare_data]
+        labels = [os.path.basename(main_arguments.input)] +\
+                 [os.path.basename(c) for c in compare_data]
+
+        legend = fig.legend(legend_lines, labels, loc = 'upper center', ncol = 3)
+        # Increase top margin to fit legend
+        fig.canvas.draw()
+        legend_height = legend.get_window_extent().inverse_transformed(fig.transFigure).height
+        plt.subplots_adjust(top = 0.98 - legend_height)
     plt.show()
 
 if __name__ == "__main__":


### PR DESCRIPTION
One of the main purpose I use jiminy for is to compare two simulations of the same system, with different parameters. In that context, I get two log files, with the same content (in terms of logged fields) and length.

This PR adds the capacity for ```jiminy_plotter``` to compare two or more logs, by plotting them on the same graph:

```jiminy_plotter logfile.data regex -c the_logs_I_want_to_compare_to.data```

Feature preview:

![simu_jiminy_standstill_DTF_JointLQR data](https://user-images.githubusercontent.com/16670497/80372770-4f962a00-8894-11ea-946f-00527aa52cbb.png)



