### PR TITLE
[core] Fix bug in FixedFrameConstraint resetProxies.

### DIFF
--- a/core/src/robot/FixedFrameConstraint.cc
+++ b/core/src/robot/FixedFrameConstraint.cc
@@ -68,6 +68,8 @@ namespace jiminy
 
     hresult_t FixedFrameConstraint::refreshProxies()
     {
+        // Resize the jacobian to the model dimension.
+        jacobian_.resize(6, model_->pncModel_.nv);
         return getFrameIdx(model_->pncModel_, frameName_, frameIdx_);
     }
 }


### PR DESCRIPTION
resetProxies was not updating the model size, leading to issues when
switching from rigid to flexible model.