### PR TITLE
[jiminy] Allow change in the unit used to log the simulation.

### DIFF
--- a/core/include/jiminy/core/Constants.h
+++ b/core/include/jiminy/core/Constants.h
@@ -25,7 +25,7 @@ namespace jiminy
 
     extern std::string const TELEMETRY_DELIMITER;
     extern int64_t const TELEMETRY_MAX_BUFFER_SIZE;
-    extern float64_t const TELEMETRY_TIME_DISCRETIZATION_FACTOR;
+    extern float64_t const TELEMETRY_DEFAULT_TIME_UNIT;
 
     extern uint8_t const DELAY_MIN_BUFFER_RESERVE; ///< Minimum memory allocation is memory is full and the older data stored is dated less than the desired delay
     extern uint8_t const DELAY_MAX_BUFFER_EXCEED;  ///< Maximum number of data stored allowed to be dated more than the desired delay

--- a/core/include/jiminy/core/engine/EngineMultiRobot.h
+++ b/core/include/jiminy/core/engine/EngineMultiRobot.h
@@ -327,6 +327,7 @@ namespace jiminy
             config["enableAcceleration"] = true;
             config["enableEffort"] = true;
             config["enableEnergy"] = true;
+            config["timeUnit"] = 1e6;
             return config;
         };
 
@@ -431,13 +432,15 @@ namespace jiminy
             bool_t const enableAcceleration;
             bool_t const enableEffort;
             bool_t const enableEnergy;
+            float64_t const timeUnit;
 
             telemetryOptions_t(configHolder_t const & options) :
             enableConfiguration(boost::get<bool_t>(options.at("enableConfiguration"))),
             enableVelocity(boost::get<bool_t>(options.at("enableVelocity"))),
             enableAcceleration(boost::get<bool_t>(options.at("enableAcceleration"))),
             enableEffort(boost::get<bool_t>(options.at("enableEffort"))),
-            enableEnergy(boost::get<bool_t>(options.at("enableEnergy")))
+            enableEnergy(boost::get<bool_t>(options.at("enableEnergy"))),
+            timeUnit(boost::get<float64_t>(options.at("timeUnit")))
             {
                 // Empty.
             }

--- a/core/include/jiminy/core/telemetry/TelemetryData.h
+++ b/core/include/jiminy/core/telemetry/TelemetryData.h
@@ -20,12 +20,11 @@ namespace jiminy
     std::string const NUM_INTS("NumIntEntries=");        ///< Number of integers in the data section.
     std::string const NUM_FLOATS("NumFloatEntries=");    ///< Number of floats in the data section.
     std::string const GLOBAL_TIME("Global.Time");        ///< Special column
+    std::string const TIME_UNIT("Global.TIME_UNIT");          ///< Special constant
     std::string const START_CONSTANTS("StartConstants"); ///< Marker of the beginning the constants section.
     std::string const START_COLUMNS("StartColumns");     ///< Marker of the beginning the columns section.
     std::string const START_LINE_TOKEN("StartLine");     ///< Marker of the beginning of a line of data.
     std::string const START_DATA("StartData");           ///< Marker of the beginning of the data section.
-    std::string const START_INPUT_FRAME("INPUT_START");  ///< Marker of the beginning of a input ethercat frame.
-    std::string const START_OUTPUT_FRAME("OUTPUT_START");///< Marker of the beginning of a output ethercat frame.
 
     std::size_t const CONSTANTS_MEM_SIZE = 16U * 1024U;
     std::size_t const INTEGERS_MEM_SIZE  = 32U * 1024U;

--- a/core/include/jiminy/core/telemetry/TelemetryRecorder.h
+++ b/core/include/jiminy/core/telemetry/TelemetryRecorder.h
@@ -40,7 +40,7 @@ namespace jiminy
 
         /// \brief Get the maximum time that can be logged with the current precision.
         /// \return Max time, in second.
-        float64_t getMaximumLogTime() const;
+        float64_t getMaximumLogTime(void) const;
 
         ////////////////////////////////////////////////////////////////////////
         /// \brief Reset the recorder.

--- a/core/include/jiminy/core/telemetry/TelemetryRecorder.h
+++ b/core/include/jiminy/core/telemetry/TelemetryRecorder.h
@@ -38,6 +38,10 @@ namespace jiminy
 
         bool_t const & getIsInitialized(void);
 
+        /// \brief Get the maximum time that can be logged with the current precision.
+        /// \return Max time, in second.
+        float64_t getMaximumLogTime() const;
+
         ////////////////////////////////////////////////////////////////////////
         /// \brief Reset the recorder.
         ////////////////////////////////////////////////////////////////////////

--- a/core/include/jiminy/core/telemetry/TelemetryRecorder.h
+++ b/core/include/jiminy/core/telemetry/TelemetryRecorder.h
@@ -29,8 +29,12 @@ namespace jiminy
 
         ////////////////////////////////////////////////////////////////////////
         /// \brief Initialize the recorder.
+        /// \param[in] telmetryData Data to log.
+        /// \param[in] timeUnit Unit with which the time will be logged
+        ///                     (note that time is logged as an int).
         ////////////////////////////////////////////////////////////////////////
-        hresult_t initialize(TelemetryData const * telemetryData);
+        hresult_t initialize(TelemetryData * telemetryData,
+                             float64_t const& timeLoggingPrecision);
 
         bool_t const & getIsInitialized(void);
 
@@ -89,6 +93,7 @@ namespace jiminy
 
         char_t const * floatsAddress_;      ///< Address of the float data section.
         int64_t floatSectionSize_;          ///< Size in byte of the float data section.
+        float64_t timeLoggingPrecision_;    ///< Precision to use when logging the time.
     };
 }
 

--- a/core/src/Constants.cc
+++ b/core/src/Constants.cc
@@ -8,13 +8,13 @@ namespace jiminy
     std::string const FLEXIBLE_JOINT_SUFFIX = "FlexibleJoint";
 
     std::string const TELEMETRY_DELIMITER = ".";
-    float64_t const TELEMETRY_TIME_DISCRETIZATION_FACTOR = 1e6; // Log the time rounded to the closest µs
+    float64_t const TELEMETRY_DEFAULT_TIME_UNIT = 1e6; // Log the time rounded to the closest µs
     int64_t const TELEMETRY_MAX_BUFFER_SIZE = 256U * 1024U; // 256Ko
 
     uint8_t const DELAY_MIN_BUFFER_RESERVE = 20U;
     uint8_t const DELAY_MAX_BUFFER_EXCEED = 20U;
 
-    float64_t const SIMULATION_MIN_TIMESTEP = 1.0 / TELEMETRY_TIME_DISCRETIZATION_FACTOR;
+    float64_t const SIMULATION_MIN_TIMESTEP = 1.0 / TELEMETRY_DEFAULT_TIME_UNIT;
     float64_t const SIMULATION_MAX_TIMESTEP = 5e-3;
     float64_t const SIMULATION_INITIAL_TIMESTEP = 1e-4;
     float64_t const STEPPER_MIN_TIMESTEP = 1e-10;

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -948,16 +948,18 @@ namespace jiminy
                numerical precision, thus avoiding it to grows unbounded. */
             float64_t stepSize_true = stepSize - stepperState_.tError;
             tEnd = stepperState_.t + stepSize_true;
-            stepperState_.tError = (tEnd - stepperState_.t) - stepSize_true;
 
-            // Check that tEnd is not too large for the current logging precision.
-            if (tEnd > telemetryRecorder_->getMaximumLogTime())
+            // Check that tEnd is not too large for the current logging precision,
+            // otherwise abort integration.
+            if (stepperState_.t + stepSize_true > telemetryRecorder_->getMaximumLogTime())
             {
                 std::cout << "Error - EngineMultiRobot::step - Time overflow: with the current precision ";
                 std::cout << "the maximum value that can be logged is " << telemetryRecorder_->getMaximumLogTime();
                 std::cout << "s. Decrease logger precision to simulate for longer than that." << std::endl;
                 return hresult_t::ERROR_GENERIC;
             }
+            stepperState_.tError = (tEnd - stepperState_.t) - stepSize_true;
+
 
             // Get references to some internal stepper buffers
             float64_t & t = stepperState_.t;

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -766,7 +766,7 @@ namespace jiminy
         configureTelemetry();
 
         // Write the header: this locks the registration of new variables
-        telemetryRecorder_->initialize(telemetryData_.get());
+        telemetryRecorder_->initialize(telemetryData_.get(), engineOptions_->telemetry.timeUnit);
 
         // Log current buffer content as first point of the log data.
         updateTelemetry();
@@ -1115,9 +1115,8 @@ namespace jiminy
                     while (tNext - t > EPS)
                     {
                         /* Adjust stepsize to end up exactly at the next breakpoint,
-                           prevent steps larger than dtMax, and make sure that dt is
-                           multiple of TELEMETRY_TIME_DISCRETIZATION_FACTOR whenever
-                           it is possible, to reduce rounding errors of logged data. */
+                           prevent steps larger than dtMax, trying to reach multiples of
+                           STEPPER_MIN_TIMESTEP whenever possible. */
                         dt = min(dt, tNext - t, engineOptions_->stepper.dtMax);
                         if (tNext - (t + dt) < STEPPER_MIN_TIMESTEP)
                         {

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -808,6 +808,15 @@ namespace jiminy
             returnCode = start(xInit, true, false);
         }
 
+        // Now that telemetry has been initialized, check simulation duration.
+        if (tEnd > telemetryRecorder_->getMaximumLogTime())
+        {
+            std::cout << "Error - EngineMultiRobot::simulate - Time overflow: with the current precision ";
+            std::cout << "the maximum value that can be logged is " << telemetryRecorder_->getMaximumLogTime();
+            std::cout << "s. Decrease logger precision to simulate for longer than that." << std::endl;
+            return hresult_t::ERROR_BAD_INPUT;
+        }
+
         // Integration loop based on boost::numeric::odeint::detail::integrate_times
         while (returnCode == hresult_t::SUCCESS)
         {
@@ -884,7 +893,7 @@ namespace jiminy
         float64_t tEnd;
         if (returnCode == hresult_t::SUCCESS)
         {
-            // Check if there is something wrong with the integration
+            // Check if there is somethiERROR_BAD_INPUTng wrong with the integration
             if ((stepperState_.x.array() != stepperState_.x.array()).any()) // isnan if NOT equal to itself
             {
                 std::cout << "Error - EngineMultiRobot::step - The low-level ode solver failed. "\
@@ -940,6 +949,15 @@ namespace jiminy
             float64_t stepSize_true = stepSize - stepperState_.tError;
             tEnd = stepperState_.t + stepSize_true;
             stepperState_.tError = (tEnd - stepperState_.t) - stepSize_true;
+
+            // Check that tEnd is not too large for the current logging precision.
+            if (tEnd > telemetryRecorder_->getMaximumLogTime())
+            {
+                std::cout << "Error - EngineMultiRobot::step - Time overflow: with the current precision ";
+                std::cout << "the maximum value that can be logged is " << telemetryRecorder_->getMaximumLogTime();
+                std::cout << "s. Decrease logger precision to simulate for longer than that." << std::endl;
+                return hresult_t::ERROR_GENERIC;
+            }
 
             // Get references to some internal stepper buffers
             float64_t & t = stepperState_.t;

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -893,7 +893,7 @@ namespace jiminy
         float64_t tEnd;
         if (returnCode == hresult_t::SUCCESS)
         {
-            // Check if there is somethiERROR_BAD_INPUTng wrong with the integration
+            // Check if there is something wrong with the integration
             if ((stepperState_.x.array() != stepperState_.x.array()).any()) // isnan if NOT equal to itself
             {
                 std::cout << "Error - EngineMultiRobot::step - The low-level ode solver failed. "\
@@ -1134,7 +1134,11 @@ namespace jiminy
                     {
                         /* Adjust stepsize to end up exactly at the next breakpoint,
                            prevent steps larger than dtMax, trying to reach multiples of
-                           STEPPER_MIN_TIMESTEP whenever possible. */
+                           STEPPER_MIN_TIMESTEP whenever possible. The idea here is to reach
+                           only multiples of 1us, making logging easier, given that, in robotics,
+                           1us can be consider an 'infinitesimal' time. This arbitrary threshold
+                           many not be suited for simulating different, faster dynamics, that require
+                           sub-microsecond precision. */
                         dt = min(dt, tNext - t, engineOptions_->stepper.dtMax);
                         if (tNext - (t + dt) < STEPPER_MIN_TIMESTEP)
                         {

--- a/core/src/telemetry/TelemetryRecorder.cc
+++ b/core/src/telemetry/TelemetryRecorder.cc
@@ -92,6 +92,11 @@ namespace jiminy
         return returnCode;
     }
 
+    float64_t TelemetryRecorder::getMaximumLogTime() const
+    {
+        return std::numeric_limits<int32_t>::max() / timeLoggingPrecision_;
+    }
+
     bool_t const & TelemetryRecorder::getIsInitialized(void)
     {
         return isInitialized_;
@@ -260,15 +265,13 @@ namespace jiminy
 
                 // In header, look for timeUnit constant - if not found, use default time unit.
                 float64_t timeUnit = TELEMETRY_DEFAULT_TIME_UNIT;
-                // Get constants
-                int32_t const lastConstantIdx = std::distance(
-                    header.begin(), std::find(header.begin(), header.end(), START_COLUMNS));
-                for (int32_t i = 1; i < lastConstantIdx; i++)
+                auto const lastConstantIt = std::find(header.begin(), header.end(), START_COLUMNS);
+                for (auto constantIt = header.begin() ; constantIt != lastConstantIt ; constantIt++)
                 {
-                    int32_t const delimiter = header[i].find("=");
-                    if (header[i].substr(0, delimiter) == TIME_UNIT)
+                    int32_t const delimiter = constantIt->find("=");
+                    if (constantIt->substr(0, delimiter) == TIME_UNIT)
                     {
-                        timeUnit = std::stof(header[i].substr(delimiter + 1));
+                        timeUnit = std::stof(constantIt->substr(delimiter + 1));
                         break;
                     }
                 }

--- a/core/src/telemetry/TelemetryRecorder.cc
+++ b/core/src/telemetry/TelemetryRecorder.cc
@@ -92,7 +92,7 @@ namespace jiminy
         return returnCode;
     }
 
-    float64_t TelemetryRecorder::getMaximumLogTime() const
+    float64_t TelemetryRecorder::getMaximumLogTime(void) const
     {
         return std::numeric_limits<int32_t>::max() / timeLoggingPrecision_;
     }


### PR DESCRIPTION
Add `Global.TIME_UNIT` constant to specify the unit in which time is logged, this enables the user to change the precision with which logging is done.