### PR TITLE
Add SensorData Python constructor

### DIFF
--- a/core/src/robot/Robot.cc
+++ b/core/src/robot/Robot.cc
@@ -1368,7 +1368,6 @@ namespace jiminy
                                  sensorConst.getIdx(),
                                  sensorConst.get());
             }
-
             data.emplace(sensorGroup.first, std::move(dataType));
         }
         return data;


### PR DESCRIPTION
- Better support of shared array between Python/C++ 
  (including bug fix related to undesired memory copy).
- Add SensorData Python constructor : The resulting C++ object is sharing memory with Python.
- Add `__repr__` method to SensorData.
- Improve efficiency of sensor data `__getitem__` method when using only sensor type as key.