### PR TITLE
Fix bug in drift computation for fixed body constraints.

### DIFF
--- a/core/include/jiminy/core/robot/FixedFrameConstraint.h
+++ b/core/include/jiminy/core/robot/FixedFrameConstraint.h
@@ -41,7 +41,7 @@ namespace jiminy
         /// \brief    Compute and return the jacobian of the constraint.
         ///
         /// \note     To avoid duplicate kinematic computation, it is assumed that
-        ///           computeJointJacobians and framesForwardKinematics has already
+        ///           computeJointJacobians and framesForwardKinematics have already
         ///           been called on model->pncModel_.
         ///
         /// \param[in] q    Current joint position.
@@ -53,7 +53,8 @@ namespace jiminy
         /// \brief    Compute and return the drift of the constraint.
         ///
         /// \note     To avoid duplicate kinematic computation, it is assumed that forward kinematics
-        ///           and jacobian computation has already been done on model->pncModel_.
+        ///           on position, velocity, and zero acceleration, and jacobian computation
+        ///           have already been done on model->pncModel_.
         ///
         /// \param[in] q    Current joint position.
         /// \param[in] v    Current joint velocity.

--- a/core/include/jiminy/core/robot/Robot.h
+++ b/core/include/jiminy/core/robot/Robot.h
@@ -205,6 +205,7 @@ namespace jiminy
         MutexLocal mutexLocal_;
         std::shared_ptr<MotorSharedDataHolder_t> motorsSharedHolder_;
         std::unordered_map<std::string, std::shared_ptr<SensorSharedDataHolder_t> > sensorsSharedHolder_;
+        vectorN_t zeroAccelerationVector_; ///< A vector of zeros of the dimension the size of the velocity vector - for computing constraints.
     };
 }
 

--- a/core/src/robot/Robot.cc
+++ b/core/src/robot/Robot.cc
@@ -35,7 +35,8 @@ namespace jiminy
     constraintsDrift_(),
     mutexLocal_(),
     motorsSharedHolder_(nullptr),
-    sensorsSharedHolder_()
+    sensorsSharedHolder_(),
+    zeroAccelerationVector_(vectorN_t::Zero(0))
     {
         // Empty on purpose
     }
@@ -572,6 +573,7 @@ namespace jiminy
             returnCode = refreshSensorsProxies();
         }
 
+
         return returnCode;
     }
 
@@ -580,6 +582,9 @@ namespace jiminy
         hresult_t returnCode = hresult_t::SUCCESS;
         vectorN_t q = pinocchio::neutral(pncModel_);
         vectorN_t v = vectorN_t::Zero(pncModel_.nv);
+
+        // Resize zeroAccelerationVector_ to the right size
+        zeroAccelerationVector_ = vectorN_t::Zero(pncModel_.nv);
 
         int constraintSize = 0;
         for (auto & constraint : constraintsHolder_)
@@ -1332,6 +1337,7 @@ namespace jiminy
     {
         // Compute joint jacobian.
         pinocchio::computeJointJacobians(pncModel_, pncData_, q);
+        pinocchio::forwardKinematics(pncModel_, pncData_, q, v, zeroAccelerationVector_);
 
         uint32_t currentRow = 0;
         for (auto & constraint : constraintsHolder_)


### PR DESCRIPTION
Drift was not computed correctly: the full body acceleration was used instead of the drift.
Fix: add a forwardKinematic pass with zero joint acceleration to compute the drift.