### PR TITLE
Sensor skew measurement rework

### DIFF
--- a/core/include/jiminy/core/robot/AbstractSensor.tpp
+++ b/core/include/jiminy/core/robot/AbstractSensor.tpp
@@ -152,9 +152,16 @@ namespace jiminy
     template <typename T>
     hresult_t AbstractSensorTpl<T>::setOptions(configHolder_t const & sensorOptions)
     {
-        AbstractSensorBase::setOptions(sensorOptions);
-        sharedHolder_->delayMax_ = std::max(sharedHolder_->delayMax_, baseSensorOptions_->delay);
-        return hresult_t::SUCCESS;
+        hresult_t returnCode = hresult_t::SUCCESS;
+
+        returnCode = AbstractSensorBase::setOptions(sensorOptions);
+
+        if (returnCode == hresult_t::SUCCESS)
+        {
+            sharedHolder_->delayMax_ = std::max(sharedHolder_->delayMax_, baseSensorOptions_->delay);
+        }
+
+        return returnCode;
     }
 
     template <typename T>

--- a/core/include/jiminy/core/robot/AbstractSensor.tpp
+++ b/core/include/jiminy/core/robot/AbstractSensor.tpp
@@ -308,10 +308,10 @@ namespace jiminy
             {
                 // Return the oldest value since the buffer is not fully initialized yet
                 auto it = std::find_if(sharedHolder_->time_.begin(), sharedHolder_->time_.end(),
-                                    [] (float64_t const & t)
-                                    {
-                                        return t > 0;
-                                    });
+                                       [] (float64_t const & t)
+                                       {
+                                           return t > 0;
+                                       });
                 if (it != sharedHolder_->time_.end())
                 {
                     int32_t ind = std::distance(sharedHolder_->time_.begin(), it);

--- a/core/include/jiminy/core/robot/AbstractSensor.tpp
+++ b/core/include/jiminy/core/robot/AbstractSensor.tpp
@@ -304,15 +304,29 @@ namespace jiminy
         }
         else
         {
-            if (sharedHolder_->time_[0] >= 0.0 || baseSensorOptions_->delay < EPS)
+            if (baseSensorOptions_->delay > EPS)
             {
-                // Return the most recent value
-                get() = sharedHolder_->data_.back().col(sensorIdx_);
+                // Return the oldest value since the buffer is not fully initialized yet
+                auto it = std::find_if(sharedHolder_->time_.begin(), sharedHolder_->time_.end(),
+                                    [] (float64_t const & t)
+                                    {
+                                        return t > 0;
+                                    });
+                if (it != sharedHolder_->time_.end())
+                {
+                    int32_t ind = std::distance(sharedHolder_->time_.begin(), it);
+                    ind = std::max(0, ind - 1);
+                    get() = sharedHolder_->data_[ind].col(sensorIdx_);
+                }
+                else
+                {
+                    get() = sharedHolder_->data_.back().col(sensorIdx_);
+                }
             }
             else
             {
-                // Return Zero since the sensor is not fully initialized yet
-                get() = sharedHolder_->data_.front().col(sensorIdx_);
+                // Return the most recent value available
+                get() = sharedHolder_->data_.back().col(sensorIdx_);
             }
         }
 

--- a/core/include/jiminy/core/robot/BasicSensors.h
+++ b/core/include/jiminy/core/robot/BasicSensors.h
@@ -36,6 +36,7 @@ namespace jiminy
     private:
         std::string frameName_;
         int32_t frameIdx_;
+        quaternion_t sensorRotationBias_; ///< Sensor rotation bias.
     };
 
     class ForceSensor : public AbstractSensorTpl<ForceSensor>

--- a/core/include/jiminy/core/robot/BasicSensors.h
+++ b/core/include/jiminy/core/robot/BasicSensors.h
@@ -20,6 +20,7 @@ namespace jiminy
 
         hresult_t initialize(std::string const & frameName);
 
+        virtual hresult_t setOptions(configHolder_t const & sensorOptions) final override;
         virtual hresult_t refreshProxies(void) final override;
 
         std::string const & getFrameName(void) const;

--- a/core/include/jiminy/core/robot/BasicSensors.h
+++ b/core/include/jiminy/core/robot/BasicSensors.h
@@ -31,6 +31,7 @@ namespace jiminy
                               Eigen::Ref<vectorN_t const> const & v,
                               Eigen::Ref<vectorN_t const> const & a,
                               vectorN_t                   const & uMotor) final override;
+        virtual void skewMeasurement(void) final override;
 
     private:
         std::string frameName_;

--- a/core/src/robot/BasicSensors.cc
+++ b/core/src/robot/BasicSensors.cc
@@ -129,27 +129,30 @@ namespace jiminy
         // Add bias
         if (baseSensorOptions_->bias.size())
         {
-            // Accel + gyroscope: simply add additive bias.
-            get().tail<6>() += baseSensorOptions_->bias.tail<6>();
-            // Quaternion: interpret bias as angle-axis representation of a sensor rotation bias R_b,
-            // such that w_R_sensor = w_R_imu R_b.
+            /* Quaternion: interpret bias as angle-axis representation of a
+               sensor rotation bias R_b, such that w_R_sensor = w_R_imu R_b. */
             get().head<4>() = (quaternion_t(get().head<4>()) *
                                quaternion_t(pinocchio::exp3(baseSensorOptions_->bias.head<3>()))).coeffs();
 
+            // Accel + gyroscope: simply add additive bias.
+            get().tail<6>() += baseSensorOptions_->bias.tail<6>();
         }
 
         // Add white noise
         if (baseSensorOptions_->noiseStd.size())
         {
-            // Accel + gyroscope: simply apply additive noise.
-            get().tail<6>() += randVectorNormal(baseSensorOptions_->noiseStd.tail<6>());
-            // Quaternion: interpret noise as a random rotation vector applied as an extra bias to the right,
-            // i.e. w_R_sensor = w_R_imu R_noise.
-            // Note that R_noise = exp3(gaussian(noiseStd)): this means the rotation vector follows a
-            // gaussian probability law, but doesn't say much in general about the rotation. However in practice
-            // we expect the standard deviation to be small, and thus the approximation to be valid.
+            /* Quaternion: interpret noise as a random rotation vector applied
+               as an extra bias to the right, i.e. w_R_sensor = w_R_imu R_noise.
+               Note that R_noise = exp3(gaussian(noiseStd)): this means the
+               rotation vector follows a gaussian probability law, but doesn't
+               say much in general about the rotation. However in practice we
+               expect the standard deviation to be small, and thus the
+               approximation to be valid. */
             get().head<4>() = (quaternion_t(get().head<4>()) *
                                quaternion_t(pinocchio::exp3(randVectorNormal(baseSensorOptions_->noiseStd.head<3>())))).coeffs();
+
+            // Accel + gyroscope: simply apply additive noise.
+            get().tail<6>() += randVectorNormal(baseSensorOptions_->noiseStd.tail<6>());
         }
 
     }

--- a/core/src/robot/BasicSensors.cc
+++ b/core/src/robot/BasicSensors.cc
@@ -131,8 +131,9 @@ namespace jiminy
         {
             /* Quaternion: interpret bias as angle-axis representation of a
                sensor rotation bias R_b, such that w_R_sensor = w_R_imu R_b. */
+            vector3_t const biasAxis = baseSensorOptions_->bias.head<3>();
             get().head<4>() = (quaternion_t(get().head<4>()) *
-                               quaternion_t(pinocchio::exp3(baseSensorOptions_->bias.head<3>()))).coeffs();
+                               quaternion_t(pinocchio::exp3(biasAxis))).coeffs();
 
             // Accel + gyroscope: simply add additive bias.
             get().tail<6>() += baseSensorOptions_->bias.tail<6>();
@@ -148,8 +149,9 @@ namespace jiminy
                say much in general about the rotation. However in practice we
                expect the standard deviation to be small, and thus the
                approximation to be valid. */
+            vector3_t const randAxis = randVectorNormal(baseSensorOptions_->noiseStd.head<3>());
             get().head<4>() = (quaternion_t(get().head<4>()) *
-                               quaternion_t(pinocchio::exp3(randVectorNormal(baseSensorOptions_->noiseStd.head<3>())))).coeffs();
+                               quaternion_t(pinocchio::exp3(randAxis))).coeffs();
 
             // Accel + gyroscope: simply apply additive noise.
             get().tail<6>() += randVectorNormal(baseSensorOptions_->noiseStd.tail<6>());

--- a/core/src/robot/BasicSensors.cc
+++ b/core/src/robot/BasicSensors.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 
+#include "pinocchio/spatial/explog.hpp"
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/algorithm/frames.hpp"
 
@@ -125,17 +126,32 @@ namespace jiminy
 
     void ImuSensor::skewMeasurement(void)
     {
-        // Add white noise
-        if (baseSensorOptions_->noiseStd.size())
-        {
-            get() += randVectorNormal(baseSensorOptions_->noiseStd);
-        }
-
         // Add bias
         if (baseSensorOptions_->bias.size())
         {
-            get() += baseSensorOptions_->bias;
+            // Accel + gyroscope: simply add additive bias.
+            get().tail<6>() += baseSensorOptions_->bias.tail<6>();
+            // Quaternion: interpret bias as angle-axis representation of a sensor rotation bias R_b,
+            // such that w_R_sensor = w_R_imu R_b.
+            get().head<4>() = (quaternion_t(get().head<4>()) *
+                               quaternion_t(pinocchio::exp3(baseSensorOptions_->bias.head<3>()))).coeffs();
+
         }
+
+        // Add white noise
+        if (baseSensorOptions_->noiseStd.size())
+        {
+            // Accel + gyroscope: simply apply additive noise.
+            get().tail<6>() += randVectorNormal(baseSensorOptions_->noiseStd.tail<6>());
+            // Quaternion: interpret noise as a random rotation vector applied as an extra bias to the right,
+            // i.e. w_R_sensor = w_R_imu R_noise.
+            // Note that R_noise = exp3(gaussian(noiseStd)): this means the rotation vector follows a
+            // gaussian probability law, but doesn't say much in general about the rotation. However in practice
+            // we expect the standard deviation to be small, and thus the approximation to be valid.
+            get().head<4>() = (quaternion_t(get().head<4>()) *
+                               quaternion_t(pinocchio::exp3(randVectorNormal(baseSensorOptions_->noiseStd.head<3>())))).coeffs();
+        }
+
     }
 
     // ===================== ForceSensor =========================

--- a/core/src/robot/BasicSensors.cc
+++ b/core/src/robot/BasicSensors.cc
@@ -102,25 +102,40 @@ namespace jiminy
             std::cout << "Error - ImuSensor::set - Sensor not initialized. Impossible to set sensor data." << std::endl;
             return hresult_t::ERROR_INIT_FAILED;
         }
-        // Compute quaternion.
+
+        // Compute quaternion
         matrix3_t const & rot = robot_->pncData_.oMf[frameIdx_].rotation();
         quaternion_t const quat(rot); // Convert a rotation matrix to a quaternion
         data().head<4>() = quat.coeffs(); // (x,y,z,w)
 
-        // Compute gyroscope signal.
+        // Compute gyroscope signal
         pinocchio::Motion const velocity = pinocchio::getFrameVelocity(robot_->pncModel_, robot_->pncData_, frameIdx_);
         data().segment<3>(4) = velocity.angular();
 
-        // Compute accelerometer signal.
+        // Compute accelerometer signal
         pinocchio::Motion const acceleration = pinocchio::getFrameAcceleration(robot_->pncModel_, robot_->pncData_, frameIdx_);
-        // Accelerometer signal is sensor linear acceleration (not spatial acceleration !) minus gravity.
+
+        // Accelerometer signal is sensor linear acceleration (not spatial acceleration !) minus gravity
         data().tail<3>() = acceleration.linear() +
                            velocity.angular().cross(velocity.linear()) -
                            quat.conjugate() * robot_->pncModel_.gravity.linear();
 
-
-
         return hresult_t::SUCCESS;
+    }
+
+    void ImuSensor::skewMeasurement(void)
+    {
+        // Add white noise
+        if (baseSensorOptions_->noiseStd.size())
+        {
+            get() += randVectorNormal(baseSensorOptions_->noiseStd);
+        }
+
+        // Add bias
+        if (baseSensorOptions_->bias.size())
+        {
+            get() += baseSensorOptions_->bias;
+        }
     }
 
     // ===================== ForceSensor =========================

--- a/unit_py/test_simple_pendulum.py
+++ b/unit_py/test_simple_pendulum.py
@@ -316,7 +316,7 @@ class SimulateSimplePendulum(unittest.TestCase):
         ], axis=-1)
 
         # Convert quaternion to a rotation vector.
-        quat_axis = np.stack([log3(Quaternion(q).matrix())
+        quat_axis = np.stack([log3(Quaternion(q[:, np.newaxis]).matrix())
                               for q in quat_jiminy], axis=0)
 
         # Estimate the quaternion noise and bias

--- a/unit_py/test_simple_pendulum.py
+++ b/unit_py/test_simple_pendulum.py
@@ -38,7 +38,7 @@ class SimulateSimplePendulum(unittest.TestCase):
         def computeCommand(t, q, v, sensor_data, u):
             u[:] = 0.0
 
-        # Dynamics: simulate a spring of stifness k
+        # Dynamics: simulate a spring of stiffness k
         k_spring = 500
         def internalDynamics(t, q, v, sensor_data, u):
             u[:] = - k_spring * q[:]
@@ -61,6 +61,7 @@ class SimulateSimplePendulum(unittest.TestCase):
 
         x0 = np.array([0.1, 0.0])
         tf = 2.0
+
         # Run simulation
         engine.simulate(tf, x0)
         log_data, _ = engine.get_log()
@@ -69,7 +70,7 @@ class SimulateSimplePendulum(unittest.TestCase):
                              for s in self.robot.logfile_position_headers + \
                                       self.robot.logfile_velocity_headers], axis=-1)
 
-        # Analytical solution: a simple mass on a spring.
+        # Analytical solution: a simple mass on a spring
         pnc_model = self.robot.pinocchio_model_th
         I = pnc_model.inertias[1].mass * pnc_model.inertias[1].lever[2] ** 2
 
@@ -105,7 +106,7 @@ class SimulateSimplePendulum(unittest.TestCase):
                              for s in self.robot.logfile_position_headers + \
                                       self.robot.logfile_velocity_headers], axis=-1)
 
-        # System dynamics: get length and inertia.
+        # System dynamics: get length and inertia
         l = -self.robot.pinocchio_model_th.inertias[1].lever[2]
         g = self.robot.pinocchio_model.gravity.linear[2]
 
@@ -113,7 +114,7 @@ class SimulateSimplePendulum(unittest.TestCase):
         def dynamics(t, x):
             return np.array([x[1], g / l * np.sin(x[0])])
 
-        # Integrate this non-linear dynamics.
+        # Integrate this non-linear dynamics
         x_rk_python = integrate_dynamics(time, x0, dynamics)
 
         # Compare the numerical and numerical integration of analytical model using scipy
@@ -138,7 +139,7 @@ class SimulateSimplePendulum(unittest.TestCase):
                  solution of a (nonlinear) pendulum motion, we perform the
                  simulation in python, with the same integrator.
         """
-        # Add IMU.
+        # Add IMU
         imu_sensor = jiminy.ImuSensor("PendulumLink")
         self.robot.attach_sensor(imu_sensor)
         imu_sensor.initialize("PendulumLink")
@@ -154,17 +155,17 @@ class SimulateSimplePendulum(unittest.TestCase):
         engine.simulate(tf, x0)
         log_data, _ = engine.get_log()
         time = log_data['Global.Time']
-        accel_jiminy = np.stack([
-            log_data['PendulumLink.Accel' + s] for s in ['x', 'y', 'z']
+        quat_jiminy = np.stack([
+            log_data['PendulumLink.Quat' + s] for s in ['x', 'y', 'z', 'w']
         ], axis=-1)
         gyro_jiminy = np.stack([
             log_data['PendulumLink.Gyro' + s] for s in ['x', 'y', 'z']
         ], axis=-1)
-        quat_jiminy = np.stack([
-            log_data['PendulumLink.Quat' + s] for s in ['x', 'y', 'z', 'w']
+        accel_jiminy = np.stack([
+            log_data['PendulumLink.Accel' + s] for s in ['x', 'y', 'z']
         ], axis=-1)
 
-        # System dynamics: get length and inertia.
+        # System dynamics: get length and inertia
         l = -self.robot.pinocchio_model_th.inertias[1].lever[2]
         g = self.robot.pinocchio_model.gravity.linear[2]
 
@@ -172,10 +173,10 @@ class SimulateSimplePendulum(unittest.TestCase):
         def dynamics(t, x):
             return np.stack([x[..., 1], g / l * np.sin(x[..., 0])], axis=-1)
 
-        # Integrate this non-linear dynamics.
+        # Integrate this non-linear dynamics
         x_rk_python = integrate_dynamics(time, x0, dynamics)
 
-        # Compute sensor acceleration, i.e. acceleration in polar coordinates.
+        # Compute sensor acceleration, i.e. acceleration in polar coordinates
         theta = x_rk_python[:, 0]
         dtheta = x_rk_python[:, 1]
 
@@ -196,14 +197,14 @@ class SimulateSimplePendulum(unittest.TestCase):
             for t in theta
         ], axis=0)
 
-        # Compare sensor signal, ignoring first iterations that correspond to system initialization.
-        self.assertTrue(np.allclose(expected_accel[2:, :], accel_jiminy[2:, :], atol=TOLERANCE))
-        self.assertTrue(np.allclose(expected_gyro[2:, :], gyro_jiminy[2:, :], atol=TOLERANCE))
+        # Compare sensor signal, ignoring first iterations that correspond to system initialization
         self.assertTrue(np.allclose(expected_quat[2:, :], quat_jiminy[2:, :], atol=TOLERANCE))
+        self.assertTrue(np.allclose(expected_gyro[2:, :], gyro_jiminy[2:, :], atol=TOLERANCE))
+        self.assertTrue(np.allclose(expected_accel[2:, :], accel_jiminy[2:, :], atol=TOLERANCE))
 
-    def test_sensor_skew(self):
+    def test_sensor_delay(self):
         """
-        @brief   Test sensor noise, bias and delay for an IMU sensor on a simple pendulum.
+        @brief   Test sensor delay for an IMU sensor on a simple pendulum.
         """
         # Add IMU.
         imu_sensor = jiminy.ImuSensor("PendulumLink")
@@ -226,8 +227,6 @@ class SimulateSimplePendulum(unittest.TestCase):
         imu_options = imu_sensor.get_options()
         imu_options['delayInterpolationOrder'] = 0
         imu_options['delay'] = 0.0
-        imu_options['noiseStd'] = np.zeros(10)
-        imu_options['bias'] = np.zeros(10)
         imu_sensor.set_options(imu_options)
 
         # Run simulation
@@ -278,7 +277,7 @@ class SimulateSimplePendulum(unittest.TestCase):
 
     def test_sensor_noise_bias(self):
         """
-        @brief   Test sensor noise and biasfor an IMU sensor on a simple pendulum in static pose.
+        @brief   Test sensor noise and bias for an IMU sensor on a simple pendulum in static pose.
         """
         # Add IMU.
         imu_sensor = jiminy.ImuSensor("PendulumLink")
@@ -290,7 +289,7 @@ class SimulateSimplePendulum(unittest.TestCase):
         engine.initialize(self.robot)
 
         x0 = np.array([0.0, 0.0])
-        tf = 100.0
+        tf = 200.0
 
         # Configure the engine: No gravity
         engine_options = engine.get_options()
@@ -299,8 +298,6 @@ class SimulateSimplePendulum(unittest.TestCase):
 
         # Configure the IMU
         imu_options = imu_sensor.get_options()
-        imu_options['delayInterpolationOrder'] = 0
-        imu_options['delay'] = 0.0
         imu_options['noiseStd'] = np.linspace(0.0, 0.2, 9)
         imu_options['bias'] = np.linspace(0.0, 1.0, 9)
         imu_sensor.set_options(imu_options)
@@ -308,26 +305,37 @@ class SimulateSimplePendulum(unittest.TestCase):
         # Run simulation
         engine.simulate(tf, x0)
         log_data, _ = engine.get_log()
-        imu_jiminy = np.stack([
-            log_data['PendulumLink.' + f] for f in jiminy.ImuSensor.fieldnames
+        quat_jiminy = np.stack([
+            log_data['PendulumLink.Quat' + s] for s in ['x', 'y', 'z', 'w']
         ], axis=-1)
-
-        # Convert quaternion to angle-axis representation.
-        imu_jiminy = np.hstack(
-                        (np.array([log3(Quaternion(d[:4].astype(float, copy=False)).matrix()) for d in imu_jiminy]),
-                        imu_jiminy[:, 4:]))
+        gyro_jiminy = np.stack([
+            log_data['PendulumLink.Gyro' + s] for s in ['x', 'y', 'z']
+        ], axis=-1)
+        accel_jiminy = np.stack([
+            log_data['PendulumLink.Accel' + s] for s in ['x', 'y', 'z']
+        ], axis=-1)
 
         # Estimate the sensor noise and bias
         # Because the IMU rotation is identy, the resulting rotation will simply be R_b R_noise.
         # Since R_noise is a small rotation, we can consider that the resulting rotation is simply
         # the rotation resulting from the sum of the rotation vector (this is only true at the first order)
         # and thus directly compare mean and standard deviation like for additive noise elsewhere.
-        imu_std = np.std(imu_jiminy, axis=0)
-        imu_bias = np.mean(imu_jiminy, axis=0)
+        quat_rpy = np.stack([log3(Quaternion(q).matrix())
+                             for q in quat_jiminy], axis=0)
+        quat_bias = np.mean(quat_rpy, axis=0)
+        quat_std = np.std(quat_rpy, axis=0)
+        gyro_std = np.std(gyro_jiminy, axis=0)
+        gyro_bias = np.mean(gyro_jiminy, axis=0)
+        accel_std = np.std(accel_jiminy, axis=0)
+        accel_bias = np.mean(accel_jiminy, axis=0)
 
-        # Compare sensor signal, ignoring first iterations that correspond to system initialization.
-        self.assertTrue(np.allclose(imu_options['noiseStd'], imu_std, atol=1.0e-2))
-        self.assertTrue(np.allclose(imu_options['bias'], imu_bias, atol=1.0e-2))
+        # Compare estimated sensor noise and bias with the configuration
+        self.assertTrue(np.allclose(imu_options['noiseStd'][:3], quat_std, atol=1.0e-2))
+        self.assertTrue(np.allclose(imu_options['bias'][:3], quat_bias, atol=1.0e-2))
+        self.assertTrue(np.allclose(imu_options['noiseStd'][3:-3], gyro_std, atol=1.0e-2))
+        self.assertTrue(np.allclose(imu_options['bias'][3:-3], gyro_bias, atol=1.0e-2))
+        self.assertTrue(np.allclose(imu_options['noiseStd'][-3:], accel_std, atol=1.0e-2))
+        self.assertTrue(np.allclose(imu_options['bias'][-3:], accel_bias, atol=1.0e-2))
 
     def test_pendulum_force_impulse(self):
         """


### PR DESCRIPTION
- Properly sensor initialization in case of delay
- Implement more realistic bias/noise for IMU quaternion since it does not make sense to use simple additive noise/bias with 4 independent coefficients
- Check the size of the user-specified bias and std at setOptions level for the IMU
- Add unit test for sensor skew measurement