### PR TITLE
Fix sensorDataMap_t Python wrapper not sharing constructor Python dict lifetime

### DIFF
--- a/gym_jiminy/gym_jiminy/common/flatten_observation.py
+++ b/gym_jiminy/gym_jiminy/common/flatten_observation.py
@@ -37,8 +37,8 @@ def flatten(space, x=None):
             raise NotImplementedError
     if x is None:
         return spaces.Box(low=_flatten_bounds(space, 'low'),
-                        high=_flatten_bounds(space, 'high'),
-                        dtype=np.float32)
+                          high=_flatten_bounds(space, 'high'),
+                          dtype=np.float32)
     else:
         return spaces.flatten(space, x)
 

--- a/gym_jiminy/gym_jiminy/common/robots.py
+++ b/gym_jiminy/gym_jiminy/common/robots.py
@@ -275,11 +275,8 @@ class RobotJiminyEnv(core.Env):
         obs['t'] = self.engine_py.t
         obs['state'] = self.engine_py.state
         obs['sensors'] = {
-            _type: {
-                name: self.engine_py.sensors_data[_type, name]
-                for name in self.engine_py.sensors_data.keys(_type)
-            }
-            for _type in self.engine_py.sensors_data.keys()
+            sensor_type: self.engine_py.sensors_data[sensor_type]
+            for sensor_type in self.engine_py.sensors_data.keys()
         }
 
     def _is_done(self):

--- a/gym_jiminy/gym_jiminy/examples/tianshou/cartpole_ppo.py
+++ b/gym_jiminy/gym_jiminy/examples/tianshou/cartpole_ppo.py
@@ -11,9 +11,9 @@ from torch.utils.tensorboard import SummaryWriter
 from tensorboard.program import TensorBoard
 from typing import Dict, List, Union, Callable, Optional
 
-from tianshou.env import VectorEnv, SubprocVectorEnv
+from tianshou.env import SubprocVectorEnv
 from tianshou.policy import BasePolicy, PPOPolicy
-from tianshou.policy.utils import DiagGaussian
+from tianshou.policy.dist import DiagGaussian
 from tianshou.trainer import test_episode, gather_info
 from tianshou.data import Collector, ReplayBuffer
 from tianshou.utils import tqdm_config, MovAvg
@@ -58,8 +58,8 @@ lr = 1.0e-3
 buffer_size = trainer_config["collect_per_step"]
 
 # Instantiate the gym environment
-train_envs = VectorEnv([lambda: env_creator() for _ in range(N_THREADS)])
-test_envs = VectorEnv([lambda: env_creator() for _ in range(N_THREADS)])
+train_envs = SubprocVectorEnv([lambda: env_creator() for _ in range(N_THREADS)])
+test_envs = SubprocVectorEnv([lambda: env_creator() for _ in range(N_THREADS)])
 
 # Set the seed
 np.random.seed(SEED)

--- a/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
+++ b/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
@@ -90,7 +90,7 @@ class EngineAsynchronous:
                     member methods of the class. It is not intended to be called
                     manually.
         """
-        self._sensors_data = sensors_data
+        self._sensors_data = sensors_data # It is already a snapshot copy of robot.sensors_data
         uCommand[:] = self._action
 
     def _internal_dynamics(self, t, q, v, sensors_data, uCommand):
@@ -187,7 +187,7 @@ class EngineAsynchronous:
 
         @return     Final state of the simulation
         """
-        if (not self.engine.is_simulation_running):
+        if not self.engine.is_simulation_running:
             flag = self.engine.start(self._state, self.use_theoretical_model)
             if (flag != jiminy.hresult_t.SUCCESS):
                 raise ValueError("Failed to start the simulation.")

--- a/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
+++ b/python/jiminy_pywrap/include/jiminy/python/Jiminy.h
@@ -404,8 +404,9 @@ namespace python
         void visit(PyClass& cl) const
         {
             cl
-                .def("__init__", bp::make_constructor(&SensorsDataMapVisitor::factory,
-                                 bp::default_call_policies(), (bp::arg("sensor_data_dict"))))
+                .def("__init__", &SensorsDataMapVisitor::factoryWrapper,
+                                 bp::with_custodian_and_ward_postcall<1, 2>(),
+                                 (bp::arg("self"), "sensors_data_dict")) // with_custodian_and_ward_postcall is used to tie the lifetime of the Python object with the one of the C++ reference, so that the Python object does not get deleted while the C++ object is not
                 .def("__len__", &SensorsDataMapVisitor::len,
                                 (bp::arg("self")))
                 .def("__getitem__", &SensorsDataMapVisitor::getItem,
@@ -578,6 +579,12 @@ namespace python
         {
             auto sensorData = convertFromPython<sensorsDataMap_t>(sensorDataPy);
             return std::make_shared<sensorsDataMap_t>(std::move(sensorData));
+        }
+
+        static void factoryWrapper(bp::object & self, bp::object & sensorDataPy)
+        {
+            auto constructor = bp::make_constructor(&SensorsDataMapVisitor::factory);
+            constructor(self, sensorDataPy);
         }
 
         ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In addition, Gym generic robot environment know returns flatten sensor data by default since it is more efficient to access individual sensor data using numpy array slicing than using dictionary keys.