### PR TITLE
Minor improvements

### DIFF
--- a/python/jiminy_py/src/jiminy_py/dynamics.py
+++ b/python/jiminy_py/src/jiminy_py/dynamics.py
@@ -317,7 +317,7 @@ def compute_freeflyer_state_from_fixed_body(robot, position, velocity=None, acce
     @param ground_profile   The ground profile callback
     """
     if not robot.has_freeflyer:
-        raise ValueError("The robot does not have a freeflyer.")
+        raise RuntimeError("The robot does not have a freeflyer.")
 
     if use_theoretical_model:
         pnc_model = robot.pinocchio_model_th

--- a/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
+++ b/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
@@ -222,7 +222,7 @@ class EngineAsynchronous:
 
         try:
             # Instantiate the robot and viewer client if necessary
-            if (self._viewer is None):
+            if not self._is_viewer_available:
                 uniq_id = next(tempfile._get_candidate_names())
                 self._viewer = Viewer(self.robot,
                                       use_theoretical_model=False,
@@ -241,12 +241,14 @@ class EngineAsynchronous:
             # Compute rgb array if needed
             if return_rgb_array:
                 rgb_array = self._viewer.captureFrame()
-        except:
-            self.close()
+        except RuntimeError:
+            Viewer.close()
             self._viewer = None
             if self._is_viewer_available:
                 self._is_viewer_available = False
-                return self.render(return_rgb_array)
+                rgb_array = self.render(return_rgb_array)
+            else:
+                RuntimeError("Impossible to create or connect to backend.")
         finally:
             return rgb_array
 

--- a/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
+++ b/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
@@ -230,8 +230,9 @@ class EngineAsynchronous:
                                       robot_name="_".join(("robot", uniq_id)),
                                       scene_name="_".join(("scene", uniq_id)),
                                       window_name="_".join(("window", uniq_id)))
-                self._viewer.setCameraTransform(translation=[0.0, 9.0, 2e-5],
-                                                rotation=[np.pi/2, 0.0, np.pi])
+                if self._viewer._backend_proc.poll() is None:
+                    self._viewer.setCameraTransform(translation=[0.0, 9.0, 2e-5],
+                                                    rotation=[np.pi/2, 0.0, np.pi])
 
             # Refresh viewer
             self._viewer.refresh()

--- a/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
+++ b/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
@@ -190,14 +190,14 @@ class EngineAsynchronous:
         if not self.engine.is_simulation_running:
             flag = self.engine.start(self._state, self.use_theoretical_model)
             if (flag != jiminy.hresult_t.SUCCESS):
-                raise ValueError("Failed to start the simulation.")
+                raise RuntimeError("Failed to start the simulation.")
 
         if (action_next is not None):
             self.action = action_next
 
         return_code = self.engine.step(dt_desired)
         if (return_code != jiminy.hresult_t.SUCCESS):
-            raise ValueError("Failed to perform the simulation step.")
+            raise RuntimeError("Failed to perform the simulation step.")
 
         self._t = self.engine.stepper_state.t
         self._state = None # Do not fetch the new current state if not requested to the sake of efficiency

--- a/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
+++ b/python/jiminy_py/src/jiminy_py/engine_asynchronous.py
@@ -230,7 +230,7 @@ class EngineAsynchronous:
                                       robot_name="_".join(("robot", uniq_id)),
                                       scene_name="_".join(("scene", uniq_id)),
                                       window_name="_".join(("window", uniq_id)))
-                if self._viewer._backend_proc.poll() is None:
+                if self._viewer.is_backend_parent:
                     self._viewer.setCameraTransform(translation=[0.0, 9.0, 2e-5],
                                                     rotation=[np.pi/2, 0.0, np.pi])
 

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -87,8 +87,8 @@ class BasicSimulator(object):
             self.controller_handle = controller_handle
             self._is_controller_handle_init = True
         except:
-            raise ValueError("The controller handle has a wrong signature. It is expected " + \
-                             "controller_handle(t, y, dy, sensorsData, u_command)")
+            raise RuntimeError("The controller handle has a wrong signature. It is expected " + \
+                               "controller_handle(t, y, dy, sensorsData, u_command)")
 
     @staticmethod
     def callback(t, q, v, out):

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -642,6 +642,17 @@ def play_trajectories(trajectory_data, mesh_root_path=None, replay_speed=1.0, vi
         if not isinstance(viewers, list):
             viewers = [viewers]
 
+        # Make sure the viewers are still running
+        is_backend_running = True
+        for viewer in viewers:
+            if viewer.is_backend_parent:
+                if viewer._backend_proc.poll() is not None:
+                    is_backend_running = False
+        if Viewer._backend_obj is None:
+            is_backend_running = False
+        if not is_backend_running:
+            raise RuntimeError("Viewers backend not available.")
+
     # Load robots in gepetto viewer
     if (xyz_offset is None):
         xyz_offset = len(trajectory_data) * (None,)

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -247,7 +247,7 @@ class Viewer:
                 if force_create_backend:
                     Viewer._create_meshcat_backend()
                 else:
-                    raise ValueError("No meshcat backend available and 'force_create_backend' is set to False.")
+                    raise RuntimeError("No meshcat backend available and 'force_create_backend' is set to False.")
 
             viewer_url = Viewer._backend_obj.url()
             if Viewer.port_forwarding is not None:
@@ -264,7 +264,7 @@ class Viewer:
 
             ipython_display(HTML(jupyter_html))
         else:
-            raise ValueError("Display in a Jupyter cell is only available using 'meshcat' backend and within a Jupyter notebook.")
+            raise RuntimeError("Display in a Jupyter cell is only available using 'meshcat' backend and within a Jupyter notebook.")
 
     @staticmethod
     def close():


### PR DESCRIPTION
- Replace ValueError by RuntimeError when the error is not directly related to argument type or value error
- Add new attribute to Viewer to keep track of backend's parent and associated subprocess
- EngineAsynchronous only setup the camera pose if it is the backend's parent
- Add optional argument 'viewers' to 'play_trajectories' to use existing viewer for display, then return the used ones
- Add non static close method to Viewer, that closes backend only if the instance opened it