### PR TITLE
Fix application of external torques

### DIFF
--- a/core/include/jiminy/core/Utilities.h
+++ b/core/include/jiminy/core/Utilities.h
@@ -321,10 +321,17 @@ namespace jiminy
                                        std::string      const & childJointNameIn,
                                        std::string      const & newJointNameIn);
 
-    pinocchio::Force computeFrameForceOnParentJoint(pinocchio::Model const & model,
+    /// \brief Convert a force expressed in the global frame of a specific frame to its parent joint frame.
+    ///
+    /// \param[in] model       Pinocchio model.
+    /// \param[in] data        Pinocchio data.
+    /// \param[in] frameIdx    Id of the frame.
+    /// \param[in] fextInWorld Force in the global frame to be converted.
+    /// \return Force in the parent joint local frame.
+    pinocchio::Force convertForceGlobalFrameToJoint(pinocchio::Model const & model,
                                                     pinocchio::Data  const & data,
                                                     int32_t          const & frameIdx,
-                                                    pinocchio::Force const & fextInWorld);
+                                                    pinocchio::Force const & fextInGlobal);
 
     // ********************** Math utilities *************************
 

--- a/core/include/jiminy/core/engine/EngineMultiRobot.h
+++ b/core/include/jiminy/core/engine/EngineMultiRobot.h
@@ -491,7 +491,8 @@ namespace jiminy
         /// \details This function registers a callback function forceFct that links
         ///          both systems by a given force. This function must return the
         ///          force that the second systems applies to the first system,
-        ///          in the world frame.
+        ///          in the global frame of the first frame (i.e. expressed at the origin
+        ///          of the first frame, in word coordinates).
         ///
         /// \param[in] systemName1 Name of the first system (the one receiving the force)
         /// \param[in] systemName2 Name of the second system (the one applying the force)
@@ -499,7 +500,7 @@ namespace jiminy
         /// \param[in] frameName2 Frame on the second system where
         ///                       (the opposite of) the force is applied.
         /// \param[in] forceFct Callback function returning the force that systemName2
-        ///                     applies on systemName1, in the world frame.
+        ///                     applies on systemName1, in the global frame of frameName1.
         hresult_t addCouplingForce(std::string            const & systemName1,
                                    std::string            const & systemName2,
                                    std::string            const & frameName1,
@@ -622,6 +623,11 @@ namespace jiminy
                                              vectorN_t          const & v,
                                              vectorN_t          const & a);
 
+        /// \brief Compute the force resulting from ground contact on a given frame.
+        ///
+        /// \param[in] system      System for which to perform computation.
+        /// \param[in] header      Id of the frame in contact.
+        /// \return Contact force, in the global frame.
         pinocchio::Force computeContactDynamics(systemDataHolder_t const & system,
                                                 int32_t            const & frameIdx) const;
 

--- a/core/include/jiminy/core/engine/EngineMultiRobot.h
+++ b/core/include/jiminy/core/engine/EngineMultiRobot.h
@@ -615,6 +615,8 @@ namespace jiminy
         stateSplitRef_t<std::add_const> splitState(vectorN_t const & val) const;
         stateSplitRef_t<> splitState(vectorN_t & val) const;
 
+        vectorN_t normalizeState(vectorN_t xCat) const; // Copy on purpose
+
         void syncStepperStateWithSystems(void);
         void syncSystemsStateWithStepper(void);
 

--- a/core/src/control/AbstractController.cc
+++ b/core/src/control/AbstractController.cc
@@ -1,5 +1,7 @@
 #include <iostream>
 
+#include "pinocchio/algorithm/joint-configuration.hpp"
+
 #include "jiminy/core/robot/Robot.h"
 #include "jiminy/core/Utilities.h"
 #include "jiminy/core/Constants.h"
@@ -39,7 +41,7 @@ namespace jiminy
             // isInitialized_ must be true to execute the 'computeCommand' and 'internalDynamics' methods
             isInitialized_ = true;
             float64_t t = 0;
-            vectorN_t q = vectorN_t::Zero(robot_->nq());
+            vectorN_t q = pinocchio::neutral(robot->pncModel_);
             vectorN_t v = vectorN_t::Zero(robot_->nv());
             vectorN_t uCommand = vectorN_t::Zero(robot_->getMotorsNames().size());
             vectorN_t uInternal = vectorN_t::Zero(robot_->nv());

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -1944,16 +1944,20 @@ namespace jiminy
         std::vector<int32_t> const & contactFramesIdx = system.robot->getContactFramesIdx();
         for (uint32_t i=0; i < contactFramesIdx.size(); i++)
         {
-            // Compute force in the contact frame.
+            // Compute force at the given contact frame.
             int32_t const & frameIdx = contactFramesIdx[i];
-            pinocchio::Force & fextInFrame = system.robot->contactForces_[i];
-            fextInFrame = computeContactDynamics(system, frameIdx);
+            pinocchio::Force & fextInGlobal = system.robot->contactForces_[i];
+            fextInGlobal = computeContactDynamics(system, frameIdx);
 
             // Apply the force at the origin of the parent joint frame
-            pinocchio::Force const fextLocal = computeFrameForceOnParentJoint(
-                system.robot->pncModel_, system.robot->pncData_, frameIdx, fextInFrame);
+            pinocchio::Force const fextLocal = convertForceGlobalFrameToJoint(
+                system.robot->pncModel_, system.robot->pncData_, frameIdx, fextInGlobal);
             int32_t const & parentIdx = system.robot->pncModel_.frames[frameIdx].parent;
             fext[parentIdx] += fextLocal;
+
+            // Convert contact force from the global frame to the local frame to store it in contactForces_.
+            system.robot->contactForces_[i].linear() = system.robot->pncData_.oMf[frameIdx].rotation().transpose() * fextInGlobal.linear();
+            system.robot->contactForces_[i].angular() = system.robot->pncData_.oMf[frameIdx].rotation().transpose() * fextInGlobal.angular();
         }
 
         // Add the effect of user-defined external impulse forces
@@ -1971,7 +1975,7 @@ namespace jiminy
                 int32_t const & parentIdx = system.robot->pncModel_.frames[frameIdx].parent;
                 pinocchio::Force const & F = forcesImpulseIt->F;
 
-                fext[parentIdx] += computeFrameForceOnParentJoint(
+                fext[parentIdx] += convertForceGlobalFrameToJoint(
                     system.robot->pncModel_, system.robot->pncData_, frameIdx, F);
             }
         }
@@ -1984,7 +1988,7 @@ namespace jiminy
             forceProfileFunctor_t const & forceFct = forceProfile.forceFct;
 
             pinocchio::Force const force = forceFct(t, q, v);
-            fext[parentIdx] += computeFrameForceOnParentJoint(
+            fext[parentIdx] += convertForceGlobalFrameToJoint(
                 system.robot->pncModel_, system.robot->pncData_, frameIdx, force);
         }
     }
@@ -2011,11 +2015,15 @@ namespace jiminy
 
             pinocchio::Force const force = forceFct(t, q1, v1, q2, v2);
             int32_t const & parentIdx1 = system1.robot->pncModel_.frames[frameIdx1].parent;
-            fext1[parentIdx1] += computeFrameForceOnParentJoint(
+            fext1[parentIdx1] += convertForceGlobalFrameToJoint(
                 system1.robot->pncModel_, system1.robot->pncData_, frameIdx1, force);
             int32_t const & parentIdx2 = system2.robot->pncModel_.frames[frameIdx2].parent;
-            fext2[parentIdx2] += computeFrameForceOnParentJoint(
-                system2.robot->pncModel_, system2.robot->pncData_, frameIdx2, -force);
+            // Move force from frame1 to frame2 to apply it to the second system.
+            pinocchio::SE3 offset(
+                matrix3_t::Identity(),
+                system1.robot->pncData_.oMf[frameIdx2].translation() - system1.robot->pncData_.oMf[frameIdx1].translation());
+            fext2[parentIdx2] += convertForceGlobalFrameToJoint(
+                system2.robot->pncModel_, system2.robot->pncData_, frameIdx2, -offset.act(force));
         }
     }
 

--- a/python/jiminy_py/MANIFEST.in
+++ b/python/jiminy_py/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include src/jiminy_py *.so *.dll *.pyd

--- a/unit_py/data/point_mass.urdf
+++ b/unit_py/data/point_mass.urdf
@@ -1,8 +1,16 @@
 <!-- This URDF describes a punctual mass: it is
 meant to unit test the contact and friction model in Jiminy.
+The force sensor is mounted with an offset rotation to verify frame computations.
 -->
 <?xml version="1.0" ?>
 <robot name="point_mass">
+    <link name="root"/>
+    <joint name="LeftSoleJoint" type="fixed">
+        <origin xyz="0.0 0.0 0.0" rpy="1.0 0.0 1.0"/>
+        <axis xyz="0.0 0.0 0.0"/>
+        <parent link="root"/>
+        <child link="MassBody"/>
+    </joint>
     <link name="MassBody">
         <inertial>
             <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>

--- a/unit_py/test_double_spring_mass.py
+++ b/unit_py/test_double_spring_mass.py
@@ -186,7 +186,8 @@ class SimulateTwoMasses(unittest.TestCase):
             f[3:] = R @ f_local[3:]
 
         def internal_dynamics(t, q, v, sensors_data, u):
-            u[:] = 0.0
+            # Apply torque on freeflyer to make it spin.
+            u[3:6] = 1.0
 
         def compute_command(t, q, v, sensors_data, u):
             # Check force computation: is the local external force what we expected ?

--- a/unit_py/test_double_spring_mass.py
+++ b/unit_py/test_double_spring_mass.py
@@ -187,6 +187,7 @@ class SimulateTwoMasses(unittest.TestCase):
 
         def internal_dynamics(t, q, v, sensors_data, u):
             # Apply torque on freeflyer to make it spin.
+            self.assertTrue(np.allclose(np.linalg.norm(q[3:7]), 1.0, atol=TOLERANCE))
             u[3:6] = 1.0
 
         def compute_command(t, q, v, sensors_data, u):

--- a/unit_py/test_point_mass.py
+++ b/unit_py/test_point_mass.py
@@ -89,7 +89,7 @@ class SimulatePointMass(unittest.TestCase):
                                np.logical_and(x_jiminy[:, 9] > 0.0, x_jiminy[:, 2] < 0.0))) > 1))
 
         # Compare the numerical and analytical equilibrium state
-        idx =self.robot.pinocchio_model.frames[self.robot.pinocchio_model.getFrameId("MassBody")].parent
+        idx = self.robot.pinocchio_model.frames[self.robot.pinocchio_model.getFrameId("MassBody")].parent
         self.assertTrue(np.allclose(-engine.system_state.f_external[idx].linear[2], mass * gravity, atol=TOLERANCE))
         self.assertTrue(np.allclose(self.k_contact * x_jiminy[-1, 2], mass * gravity, atol=TOLERANCE))
 
@@ -118,7 +118,7 @@ class SimulatePointMass(unittest.TestCase):
         idx = self.robot.pinocchio_model.getFrameId("MassBody")
         def computeCommand(t, q, v, sensors_data, u):
             # Verify sensor data.
-            f =  Force(sensors_data[jiminy.ForceSensor.type, "MassBody"], np.zeros(3))
+            f = Force(sensors_data[jiminy.ForceSensor.type, "MassBody"], np.zeros(3))
             f_joint_sensor = self.robot.pinocchio_model.frames[idx].placement * f
             f_jiminy = engine.system_state.f_external[self.robot.pinocchio_model.frames[idx].parent]
             self.assertTrue(np.allclose(f_joint_sensor.vector, f_jiminy.vector, atol=TOLERANCE))

--- a/unit_py/test_point_mass.py
+++ b/unit_py/test_point_mass.py
@@ -2,6 +2,7 @@
 # method of jiminy on simple models.
 import unittest
 import numpy as np
+from pinocchio import Force
 
 from jiminy_py import core as jiminy
 
@@ -88,8 +89,56 @@ class SimulatePointMass(unittest.TestCase):
                                np.logical_and(x_jiminy[:, 9] > 0.0, x_jiminy[:, 2] < 0.0))) > 1))
 
         # Compare the numerical and analytical equilibrium state
-        self.assertTrue(np.allclose(-log_data['MassBody.FZ'][-1], mass * gravity, atol=TOLERANCE))
+        idx =self.robot.pinocchio_model.frames[self.robot.pinocchio_model.getFrameId("MassBody")].parent
+        self.assertTrue(np.allclose(-engine.system_state.f_external[idx].linear[2], mass * gravity, atol=TOLERANCE))
         self.assertTrue(np.allclose(self.k_contact * x_jiminy[-1, 2], mass * gravity, atol=TOLERANCE))
+
+
+    def test_force_sensor(self):
+        """
+        @brief Validate output of force sensor.
+
+        @details The energy is expected to decrease slowly when penetrating into the ground,
+                 but should stay constant otherwise. Then, the equilibrium point must also
+                 match the physics. Note that the friction model is not assessed here.
+        """
+        # Create the engine
+        engine = jiminy.Engine()
+        engine.initialize(self.robot)
+
+        engine_options = engine.get_options()
+        engine_options['contacts']['stiffness'] = self.k_contact
+        engine_options['contacts']['damping'] = self.nu_contact
+        engine_options['contacts']['transitionEps'] = 1.0 / self.k_contact # To avoid assertion failure because of problem regularization
+        engine_options["stepper"]["dtMax"] = self.dtMax
+        engine_options["stepper"]["logInternalStepperSteps"] = True
+        engine.set_options(engine_options)
+
+
+        idx = self.robot.pinocchio_model.getFrameId("MassBody")
+        def computeCommand(t, q, v, sensors_data, u):
+            # Verify sensor data.
+            f =  Force(sensors_data[jiminy.ForceSensor.type, "MassBody"], np.zeros(3))
+            f_joint_sensor = self.robot.pinocchio_model.frames[idx].placement * f
+            f_jiminy = engine.system_state.f_external[self.robot.pinocchio_model.frames[idx].parent]
+            self.assertTrue(np.allclose(f_joint_sensor.vector, f_jiminy.vector, atol=TOLERANCE))
+            u[:] = 0.0
+
+        # Internal dynamics: make the mass spin to generate nontrivial rotations.
+        def internalDynamics(t, q, v, sensors_data, u):
+            u[3:6] = 1.0
+
+        controller = jiminy.ControllerFunctor(computeCommand, internalDynamics)
+        controller.initialize(self.robot)
+        engine = jiminy.Engine()
+        engine.initialize(self.robot, controller)
+
+        # Run simulation
+        x0 = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+                       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ]) # [TX,TY,TZ],[QX,QY,QZ,QW]
+        tf = 1.5
+
+        engine.simulate(tf, x0)
 
     def test_friction_model(self):
         """


### PR DESCRIPTION
The formula for handling external torques was wrong due to misunderstanding between local, global and world frame: this has been clarified.

Force sensors returned values in the world frame instead of their sensor frame.

Added unit test of both of these features.

_____________________

It also fixes an issue with quaternion integration slowly diverging from SE3 over time by "normalizing" the configuration vector before and after each internal stepper step.