### PR TITLE
Jiminy release 1.2.43

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.2.42)
+set(BUILD_VERSION 1.2.43)
 
 # Add definition of Jiminy version for C++ headers
 add_definitions("-DJIMINY_VERSION=\"${BUILD_VERSION}\"")

--- a/build_tools/cmake/base.cmake
+++ b/build_tools/cmake/base.cmake
@@ -1,14 +1,6 @@
 # Minimum version required
 cmake_minimum_required (VERSION 3.10)
 
-# Enable ccache if available
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-    message("-- Enabling ccache.")
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
-
 # Check if network is available for compiling gtest
 option(BUILD_TESTING "Build the gtest testing tree." ON)
 if(BUILD_TESTING)

--- a/build_tools/cmake/base.cmake
+++ b/build_tools/cmake/base.cmake
@@ -1,6 +1,14 @@
 # Minimum version required
 cmake_minimum_required (VERSION 3.10)
 
+# Enable ccache if available
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+    message("-- Enabling ccache.")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
+
 # Check if network is available for compiling gtest
 option(BUILD_TESTING "Build the gtest testing tree." ON)
 if(BUILD_TESTING)

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -423,7 +423,7 @@ class Viewer:
             meshcat_port = [
                 conn.laddr.port for conn in psutil.net_connections("tcp4")
                 if conn.status == 'LISTEN' and \
-                    psutil.Process(conn.pid).cmdline()[-1] == 'meshcat.servers.zmqserver']
+                    'meshcat' in psutil.Process(conn.pid).cmdline()[-1]]
 
             # Use the first port responding, if any
             zmq_url = None


### PR DESCRIPTION
- [jiminy_py/Viewer] Remove restriction of `refresh` method to `use_theoretical_model = False`. Incidentally, it fixes  exception raising at init for `use_theoretical_model = False`
- [jiminy_py/Viewer] Fix bug opening new navigator window even if `is_backend_parent = False` for `meshcat` backend
- [jiminy_py/Viewer] Fix detection of meshcat server executed using `meshcat-server` executable script (Python "entry-point").