### PR TITLE
[Viewer] Improve meshcat capture frame efficiency

### DIFF
--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -10,15 +10,19 @@
 
         <script type="text/javascript" src="main.min.js"></script>
         <script>
+            // Instantiate a new Meshcat viewer
             var viewer = new MeshCat.Viewer(document.getElementById("meshcat-pane"), false);
 
+            // Monkey-patch 'set_object_from_json' and
+            // 'handle_command' to add support of custom
+            // 'meshes_loaded' command, which is used to return
+            // the number of meshes already loading in viewer.
             var meshes_loaded = 0;
             var set_object_from_json = viewer.set_object_from_json;
             viewer.set_object_from_json = function(path, object_json) {
                 set_object_from_json.call(this, path, object_json);
                 meshes_loaded += 1;
             };
-
             var handle_command = viewer.handle_command;
             viewer.handle_command = function(cmd) {
                 if (cmd.type == "meshes_loaded") {
@@ -28,12 +32,16 @@
                 }
             };
 
+            // Connect the viewer to the existing server, if any
             try {
                 viewer.connect();
             } catch (e) {
                 console.info("Not connected to MeshCat websocket server: ", e);
             }
 
+            // Replace the mesh grid by a filled checkerboard,
+            // similar to the one of Gepetto-gui. The pvaing size
+            // is 1m by 1m for convenience.
             var segments = 20;
             var geometry = new MeshCat.THREE.PlaneGeometry(20, 20, segments, segments);
             var materialEven = new MeshCat.THREE.MeshBasicMaterial(
@@ -53,20 +61,29 @@
 
             viewer.scene_tree.find(["Axes", "<object>"]).object.material.linewidth = 2.5
 
+            // Update the "zoom" of the camera to match the
+            // behavior of Gepetto-gui, and update the default
+            // position of the camera accordingly.
             viewer.camera.fov = 30;
             viewer.camera.position.set(8.0, 1.2, 0);
             viewer.render();
 
+            // Fix 'capture_image' and 'animate' methods to NOT
+            // automatically update controls, which would prevent
+            // free control of the camera programmatically.
+            // Note that it does not disable controls update while
+            // moving the camera using the mouse, which is nice
+            // because it enforces the camera to be "straight".
             viewer.capture_image = function() {
                 viewer.camera.updateProjectionMatrix();
                 viewer.renderer.render(viewer.scene, viewer.camera);
-                viewer.animator.after_render();
                 viewer.needs_render = false;
                 return viewer.renderer.domElement.toDataURL();
             };
-
             function animate() {
-                requestAnimationFrame(animate);
+                if (continue_animating) {
+                    requestAnimationFrame(animate);
+                }
                 viewer.animator.update();
                 if (viewer.needs_render) {
                     viewer.camera.updateProjectionMatrix();
@@ -75,7 +92,17 @@
                     viewer.needs_render = false;
                 }
             }
-            animate();
+
+            // Enable start and stop animation on-the-fly
+            var continue_animating = true;
+            function start_animate() {
+                continue_animating = true;
+                animate()
+            }
+            function stop_animate() {
+                continue_animating = false;
+            }
+            start_animate();
         </script>
 
         <style>

--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -77,8 +77,7 @@
             viewer.capture_image = function() {
                 viewer.camera.updateProjectionMatrix();
                 viewer.renderer.render(viewer.scene, viewer.camera);
-                viewer.needs_render = false;
-                return viewer.renderer.domElement.toDataURL();
+                return viewer.renderer.domElement.toDataURL('image/webp', 1.0);
             };
             function animate() {
                 if (continue_animating) {

--- a/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
@@ -94,14 +94,17 @@ def meshcat_recorder(meshcat_url,
                      img_data_html_shm,
                      width_shm,
                      height_shm):
-    # Do not catch signal interrupt automatically, to avoid
-    # killing meshcat server and stopping Jupyter notebook cell.
+    # Do not catch signal interrupt automatically, to avoid killing meshcat
+    # server and stopping Jupyter notebook cell.
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
+    # Open a Meshcat client in background in a hidden chrome browser instance
     session = HTMLSession()
     client = session.get(meshcat_url)
     client.html.render(keep_page=True)
 
+    # Stop rendering loop since it is irrelevant in his case, because
+    # capture_frame is already doing the job.
     async def stop_animation_async(client):
         return await client.html.page.evaluate("""
             () => {
@@ -114,6 +117,7 @@ def meshcat_recorder(meshcat_url,
     with open(os.devnull, 'w') as f:
         with redirect_stderr(f):
             while True:
+                # Wait for request to take a screenshot
                 if take_snapshot_shm.value:
                     img_data_html_shm.value = capture_frame(
                         client, width_shm.value, height_shm.value)

--- a/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
@@ -25,6 +25,7 @@ async def launch(self) -> Browser:
 
     options = dict()
     options['env'] = self.env
+    cmd = self.cmd + [" --disable-frame-rate-limit", " --disable-gpu-vsync"]
     if not self.dumpio:
         options['stdout'] = subprocess.PIPE
         options['stderr'] = subprocess.STDOUT
@@ -32,10 +33,10 @@ async def launch(self) -> Browser:
         startupflags = subprocess.DETACHED_PROCESS | \
             subprocess.CREATE_NEW_PROCESS_GROUP
         self.proc = subprocess.Popen(
-            self.cmd, **options, creationflags=startupflags, shell=False)
+            cmd, **options, creationflags=startupflags, shell=False)
     else:
         self.proc = subprocess.Popen(
-            self.cmd, **options, preexec_fn=os.setpgrp, shell=False)
+            cmd, **options, preexec_fn=os.setpgrp, shell=False)
 
     # don't forget to close browser process
     def _close_process(*args, **kwargs) -> None:

--- a/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
@@ -81,7 +81,7 @@ def capture_frame(client, width, height):
                 {'width': width, 'height': height})
         return await client.html.page.evaluate("""
             () => {
-            return viewer.capture_image();
+                return viewer.capture_image();
             }
         """)
     loop = asyncio.get_event_loop()
@@ -100,6 +100,15 @@ def meshcat_recorder(meshcat_url,
     session = HTMLSession()
     client = session.get(meshcat_url)
     client.html.render(keep_page=True)
+
+    async def stop_animation_async(client):
+        return await client.html.page.evaluate("""
+            () => {
+                stop_animate();
+            }
+        """)
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(stop_animation_async(client))
 
     with open(os.devnull, 'w') as f:
         with redirect_stderr(f):

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -936,12 +936,12 @@ class Viewer:
             # Parse the output to remove the html header, and
             # convert it into the desired output format.
             img_data = base64.decodebytes(str.encode(
-                recorder_shm['img_data_html'].value[22:]))
+                recorder_shm['img_data_html'].value[23:]))
             if raw_data:
                 return img_data
             else:
                 img_obj = Image.open(io.BytesIO(img_data))
-                rgb_array = np.array(img_obj)[:, :, :-1]
+                rgb_array = np.array(img_obj)
                 return rgb_array
 
     def save_frame(self, output_path, width=None, height=None):
@@ -951,18 +951,19 @@ class Viewer:
         @remark     This method is currently not available on Jupyter using
                     Meshcat backend because of asyncio conflict.
 
-        @param[in]  output_path    Fullpath of the image (.png extension is mandatory)
+        @param[in]  output_path    Fullpath of the image (.png extension is mandatory for
+                                   Gepetto-gui, it is .webp for Meshcat)
         @param[in]  width     Width for the image in pixels (not available with Gepetto-gui for now).
                               Optional: DEFAULT_SIZE by default. None to keep the original size
         @param[in]  height    Height for the image in pixels (not available with Gepetto-gui for now).
                               Optional: DEFAULT_SIZE by default. None to keep the original size
         """
-        if not output_path.endswith('.png'):
-            raise ValueError("The output path must have .png extension.")
         if Viewer.backend == 'gepetto-gui':
+            output_path = str(pathlib.Path(output_path).with_suffix('.png'))
             self._client.captureFrame(self._window_id, output_path)
         else:
             img_data = self.capture_frame(width, height, True)
+            output_path = str(pathlib.Path(output_path).with_suffix('.webp'))
             with open(output_path, "wb") as f:
                 f.write(img_data)
 
@@ -1143,12 +1144,12 @@ def play_trajectories(trajectory_data,
     @param[in]  trajectory_data     List of trajectory dictionary with keys:
                                     'evolution_robot': list of State object of increasing time
                                     'robot': jiminy robot (None if omitted)
-                                    'use_theoretical_model':  whether to use the theoretical or actual model
+                                    'use_theoretical_model': whether to use the theoretical or actual model
     @param[in]  mesh_root_path      Optional, path to the folder containing the URDF meshes.
     @param[in]  replay_speed        Speed ratio of the simulation
                                     Optional: 1.0 by default
-    @param[in]  record_video_path   Fullpath location where to save generated video. Must be
-                                    specified to enable video recording.
+    @param[in]  record_video_path   Fullpath location where to save generated video (.mp4 extension is
+                                    mandatory). Must be specified to enable video recording.
                                     Optional: None to disable. None by default.
     @param[in]  viewers             Already instantiated viewers, associated one by one in order to
                                     each trajectory data.


### PR DESCRIPTION
- [Viewer] Capture frame using Meshcat in ".webp" format instead of ".png" to improve efficiency
- [Viewer] Minor performance improvement of backend recorder thread by avoiding useless rendering operations