### PR TITLE
[Viewer] Add native support of Jupyter and Google Colab

### DIFF
--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -121,6 +121,11 @@
                 continue_animating = false;
             }
             start_animate();
+
+            window.onunload = function(event) {
+                viewer.connection.close();
+                return false;
+            }
         </script>
 
         <style>

--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -123,6 +123,7 @@
             start_animate();
 
             window.onunload = function(event) {
+                console.log("Closing connection...")
                 viewer.connection.close();
                 return false;
             }

--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -36,7 +36,7 @@
                     console.log("connection to Google Colab kernel:", viewer.connection);
                     (async function() {
                         for await (const message of channel.messages) {
-                            viewer.handle_command(message.data);
+                            viewer.handle_command_bytearray(new Uint8Array(message.buffers[0].buffer));
                         }
                         console.log("connection to Google Colab kernel closed.");
                     })();

--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -8,7 +8,6 @@
 	<body>
         <div id="meshcat-pane"></div>
 
-
         <script type="text/javascript" src="main.min.js"></script>
         <script type="text/javascript" src="webm-writer-0.3.0.js"></script>
         <script>
@@ -22,17 +21,41 @@
             var handle_command = viewer.handle_command;
             viewer.handle_command = function(cmd) {
                 if (cmd.type == "ready") {
-                    this.connection.send("ok");
+                    viewer.connection.send("ok");
                 } else {
                     handle_command.call(this, cmd);
                 }
             };
 
-            // Connect the viewer to the existing server, if any
+            // Connect the viewer to the existing server, using the
+            // usual websocket on desktop, though kernel communication
+            // in Google Colaboratory or Jupyter notebooks.
             try {
-                viewer.connect();
+                if (typeof google !== 'undefined') {
+                    viewer.connection = google.colab.kernel.comms.open('meshcat');
+                    console.log("connection to Google Colab kernel:", viewer.connection);
+                    (async function() {
+                        for await (const message of channel.messages) {
+                            viewer.handle_command(message.data);
+                        }
+                        console.log("connection to Google Colab kernel closed.");
+                    })();
+                }
+                else if(typeof window.parent.Jupyter !== 'undefined') {
+                    viewer.connection = window.parent.Jupyter.notebook.kernel.comm_manager.new_comm('meshcat');
+                    console.log("connection to Jupyter kernel:", viewer.connection);
+                    viewer.connection.on_msg(function(message) {
+                        viewer.handle_command_bytearray(new Uint8Array(message.buffers[0].buffer));
+                    });
+                    viewer.connection.on_close(function(evt) {
+                        console.log("connection to Jupyter kernel closed:", evt);
+                    });
+                }
+                else {
+                    viewer.connect();
+                }
             } catch (e) {
-                console.info("Not connected to MeshCat websocket server: ", e);
+                console.info("Not connected to MeshCat server: ", e);
             }
 
             // Replace the mesh grid by a filled checkerboard, similar to

--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -47,7 +47,7 @@
                     viewer.connection.on_msg(function(message) {
                         viewer.handle_command_bytearray(new Uint8Array(message.buffers[0].buffer));
                     });
-                    viewer.connection.on_close(function(evt) {
+                    viewer.connection.on_close(function(message) {
                         console.log("connection to Jupyter kernel closed:", evt);
                     });
                 }

--- a/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/recorder.py
@@ -8,6 +8,7 @@ import pathlib
 import asyncio
 import subprocess
 import multiprocessing
+import multiprocessing.managers
 from ctypes import c_char_p, c_bool, c_int
 from contextlib import redirect_stderr
 

--- a/python/jiminy_py/src/jiminy_py/meshcat/server.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/server.py
@@ -111,7 +111,7 @@ class ZMQWebSocketIpythonBridge(ZMQWebSocketBridge):
         ])
 
     def wait_for_websockets(self):
-        if len(self.websocket_pool) > 0 or len(self.comm_pool) > 0:
+        if self.websocket_pool or self.comm_pool:
             self.zmq_socket.send(b"ok")
             self.zmq_stream.flush()
         else:

--- a/python/jiminy_py/src/jiminy_py/meshcat/server.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/server.py
@@ -75,15 +75,19 @@ def handle_web(self, message):
 WebSocketHandler.on_message = handle_web
 
 class ZMQWebSocketIpythonBridge(ZMQWebSocketBridge):
-    def __init__(self, zmq_url=None, host="127.0.0.1", port=None):
+    def __init__(self, zmq_url=None, comm_url=None, host="127.0.0.1", port=None):
         super().__init__(zmq_url, host, port)
 
         # Create a new zmq socket specifically for kernel communications
-        def f(port):
-            return self.setup_comm("{:s}://{:s}:{:d}".format(
-                DEFAULT_ZMQ_METHOD, self.host, port))
-        (self.comm_zmq, self.comm_stream, self.comm_url), _ = \
-            find_available_port(f, DEFAULT_COMM_PORT)
+        if comm_url is None:
+            def f(port):
+                return self.setup_comm("{:s}://{:s}:{:d}".format(
+                    DEFAULT_ZMQ_METHOD, self.host, port))
+            (self.comm_zmq, self.comm_stream, self.comm_url), _ = \
+                find_available_port(f, DEFAULT_COMM_PORT)
+        else:
+             self.comm_zmq, self.comm_stream, self.comm_url = \
+                 self.setup_comm(comm_url)
 
         # Extra buffers for  comm ids and messages
         self.comm_pool = []

--- a/python/jiminy_py/src/jiminy_py/meshcat/wrapper.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/wrapper.py
@@ -1,7 +1,10 @@
 import atexit
+import asyncio
+from heapq import heappop
 from contextlib import redirect_stdout
 
 import zmq
+from zmq.eventloop.zmqstream import ZMQStream
 
 import meshcat
 
@@ -9,24 +12,127 @@ from .recorder import MeshcatRecorder
 
 
 class MeshcatWrapper:
-    def __init__(self, zmq_url):
+    def __init__(self, zmq_url, comm_url):
         with redirect_stdout(None):
             self.gui = meshcat.Visualizer(zmq_url)
         self.__zmq_socket = self.gui.window.zmq_socket
         self.recorder = MeshcatRecorder(self.gui.url())
+
+        # Create ZMQ socket from/to Ipython Kernel bridge to forward
+        # communications the Javascript frontend in a notebook cell to the ZMQ
+        # socket of the Meshcat server in both directions. Note that it must be
+        # done on host, not on remote, because kernel communication are not
+        # available not official supported. Forwarding communications from
+        # Ipython kernel to ZMQ socket is implemented using 'comm.on_msg'
+        # handle, which is managed by the  kernel and synchronized with the
+        # main asyncio loop. The other direction is handled using dedicated ZMQ
+        # sockets using ROUTER/ROUTER protocol. It also sending and receiving
+        # any number of messages from both sides without systematic reply, much
+        # like PUB/SUB + SUB/PUB double sockets. Note that ROUTER/ROUTER
+        # communication is supported by the standard but not encouraged. It has
+        # been chosen to add extra ROUTER/ROUTER sockets instead of replacing
+        # the original ones to avoid altering too much the original
+        # implementation of Meshcat.
+        self.n_comm = 0
+        self.__n_message = 0
+        try:
+            self.__kernel = get_ipython().kernel
+        except (NameError, AttributeError):
+            pass  # No backend Ipython kernel available. Not listening for incoming connections.
+        else:
+            context = zmq.Context().instance()
+            self.__comm_socket = context.socket(zmq.XREQ)
+            self.__comm_socket.connect(comm_url)
+            self.__comm_stream = ZMQStream(self.__comm_socket)
+            self.__comm_stream.on_recv(self.__forward_to_ipython)
+            self.__kernel.comm_manager.register_target(
+                'meshcat', self.__comm_register)
+
         atexit.register(self.close)
 
     def __del__(self):
         self.close()
 
     def close(self):
+        self.n_comm = 0
+        self.__n_message = 0
         self.recorder.release()
+        if self.__kernel is not None:
+            self.__kernel.comm_manager.unregister_target(
+                'meshcat', self.__comm_register)
+        self.__comm_stream.close(linger=5)
+        self.__comm_socket.close(linger=5)
+
+    def __forward_to_ipython(self, messages):
+        from IPython import get_ipython
+        comm_pool = get_ipython().kernel.comm_manager.comms
+        for message in messages:
+            comm_id = message[:32].decode()  # comm_id is always 32 bits
+            comm_pool[comm_id].send(buffers=[message[32:]])
+
+    def __comm_register(self, comm, msg):
+        # There is a major limitation of using 'comm.on_msg' callback
+        # mechanism: if the main thread is already busy for some reason, for
+        # instance waiting for a reply from the server ZMQ socket, then
+        # 'comm.on_msg' will NOT triggered automatically. It is only triggered
+        # automatically once every other tacks has been process. The workaround
+        # is to interleave blocking code with call of 'kernel.do_one_iteration'
+        # or 'await kernel.process_one(wait=True)'. See Stackoverflow for ref.
+        # https://stackoverflow.com/questions/63651823/direct-communication-between-javascript-in-jupyter-and-server-via-ipython-kernel/63666477#63666477
+        @comm.on_msg
+        def _on_msg(msg):
+            self.__n_message += 1
+            data = msg['content']['data']  # TODO: Check compatibility with Google Colab
+            self.__comm_socket.send(f"data:{comm.comm_id}:{data}".encode())
+
+        @comm.on_close
+        def _close(evt):
+            self.n_comm -= 1
+            self.__comm_socket.send(f"close:{comm.comm_id}".encode())
+
+        self.n_comm += 1
+        self.__comm_socket.send(f"open:{comm.comm_id}".encode())
+
+    @staticmethod
+    def __recv(coro):
+        loop = asyncio.get_event_loop()
+        f = asyncio.ensure_future(coro)
+        while not f.done():
+            # Extract from the implementation of 'run_until_complete' in
+            # 'nested_asyncio' package. Check Github for reference
+            # https://github.com/erdewit/nest_asyncio/blob/43467067b87b20325c4cbaaf78af8eff16ecf847/nest_asyncio.py#L80
+            now = loop.time()
+            ready = loop._ready
+            scheduled = loop._scheduled
+            while scheduled and scheduled[0]._cancelled:
+                heappop(scheduled)
+            timeout = 0 if ready or loop._stopping \
+                else min(max(0, scheduled[0]._when - now), 10) if scheduled \
+                else None
+            event_list = loop._selector.select(timeout)
+            loop._process_events(event_list)
+            while scheduled and scheduled[0]._when < now + loop._clock_resolution:
+                handle = heappop(scheduled)
+                ready.append(handle)
+            while ready:
+                handle = ready.popleft()
+                if not handle._cancelled:
+                    handle._run()
+            handle = None
+        return f.result()
 
     def wait(self, require_client=False):
         if require_client:
             self.gui.wait()
+
+        async def wait_async():
+            while self.__n_message < self.n_comm:
+                await self.__kernel.process_one(wait=True)
+            return self.__zmq_socket.recv().decode("utf-8")
+
+        self.__n_message = 0
         self.__zmq_socket.send(b"ready")
-        self.__zmq_socket.recv().decode("utf-8")
+        self.__recv(wait_async())
 
     def start_recording(self, fps, width, height):
         if not self.recorder.is_open:

--- a/python/jiminy_py/src/jiminy_py/meshcat/wrapper.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/wrapper.py
@@ -1,6 +1,8 @@
 import atexit
 from contextlib import redirect_stdout
 
+import zmq
+
 import meshcat
 
 from .recorder import MeshcatRecorder

--- a/python/jiminy_py/src/jiminy_py/meshcat/wrapper.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/wrapper.py
@@ -2,29 +2,134 @@ import atexit
 import asyncio
 import threading
 import tornado.ioloop
-from heapq import heappop
 from contextlib import redirect_stdout
 
 import zmq
 from zmq.eventloop.zmqstream import ZMQStream
 
 import meshcat
+from .server import start_meshcat_server
 
 from .recorder import MeshcatRecorder
 
 
-_send_orig = meshcat.visualizer.ViewerWindow.send
-def _send(self, command):
-    _send_orig(self, command)
-    get_ipython().kernel.do_one_iteration() # TODO : detect if needed
-meshcat.visualizer.ViewerWindow.send = _send
+def is_notebook():
+    """
+    @brief Determine whether Python is running inside a Notebook or not.
+    """
+    from IPython import get_ipython
+    shell = get_ipython().__class__.__module__
+    if shell == 'ipykernel.zmqshell':
+        return 1   # Jupyter notebook or qtconsole. Impossible to discriminate easily without costly psutil inspection of the running process...
+    elif shell == 'IPython.terminal.interactiveshell':
+        return 0   # Terminal running IPython
+    elif shell.startswith('google.colab.'):
+        return 2   # Google Colaboratory
+    elif shell == '__builtin__':
+        return 0   # Terminal running Python
+    else:
+        return 0   # Unidentified type
+
+
+# Monkey-patch meshcat ViewerWindow 'send' method to process queued comm
+# messages. Otherwise, new opening comm will not be detected soon enough.
+if is_notebook():
+    from IPython import get_ipython
+    _send_orig = meshcat.visualizer.ViewerWindow.send
+    def _send(self, command):
+        _send_orig(self, command)
+        get_ipython().kernel.do_one_iteration()
+    meshcat.visualizer.ViewerWindow.send = _send
+
+
+class CommManager:
+    def __init__(self, comm_url):
+        self.n_comm = 0
+        self.n_message = 0
+
+        def forward_comm_thread():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            ioloop = tornado.ioloop.IOLoop()
+            context = zmq.Context()
+            self.__comm_socket = context.socket(zmq.XREQ)
+            self.__comm_socket.connect(comm_url)
+            self.__comm_stream = ZMQStream(self.__comm_socket)
+            self.__comm_stream.on_recv(self.__forward_to_ipython)
+            ioloop.start()
+        self.__thread = threading.Thread(target=forward_comm_thread)
+        self.__thread.daemon = True
+        self.__thread.start()
+
+        self.__kernel = get_ipython().kernel
+        self.__kernel.comm_manager.register_target(
+            'meshcat', self.__comm_register)
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        self.n_comm = 0
+        self.n_message = 0
+        self.__kernel.comm_manager.unregister_target(
+            'meshcat', self.__comm_register)
+        self.__thread._stop()
+        self.__comm_stream.close(linger=5)
+        self.__comm_socket.close(linger=5)
+
+    def __forward_to_ipython(self, frames):
+        comm_pool = self.__kernel.comm_manager.comms
+        cmd = frames[0]  # There is always a single command
+        comm_id = cmd[:32].decode()  # comm_id is always 32 bits
+        comm_pool[comm_id].send(buffers=[cmd[32:]])
+
+    def __comm_register(self, comm, msg):
+        # There is a major limitation of using 'comm.on_msg' callback
+        # mechanism: if the main thread is already busy for some reason, for
+        # instance waiting for a reply from the server ZMQ socket, then
+        # 'comm.on_msg' will NOT triggered automatically. It is only triggered
+        # automatically once every other tacks has been process. The workaround
+        # is to interleave blocking code with call of 'kernel.do_one_iteration'
+        # or 'await kernel.process_one(wait=True)'. See Stackoverflow for ref.
+        # https://stackoverflow.com/questions/63651823/direct-communication-between-javascript-in-jupyter-and-server-via-ipython-kernel/63666477#63666477
+        # TODO Calling 'do_one_iteration' messes up with the kernel 'msg_queue',
+        # so that some messages will be processed too soon. It would be better
+        # to deal with the stack manually, 'get' each messages, and check if it
+        # must be handle now are later, then put it back in the stack if so.
+        # https://github.com/ipython/ipykernel/blob/e048a93d93e11b19e25fb13c4eb7b4cb44ea081c/ipykernel/kernelbase.py#L348
+        @comm.on_msg
+        def _on_msg(msg):
+            self.n_message += 1
+            if is_notebook() == 1:  # Jupyter notebook
+                data = msg['content']['data']
+            else:  # Google Colab
+                data = msg['data']  # TODO: Check compatibility with Google Colab
+            self.__comm_socket.send(f"data:{comm.comm_id}:{data}".encode())
+
+        @comm.on_close
+        def _close(evt):
+            self.n_comm -= 1
+            self.__comm_socket.send(f"close:{comm.comm_id}".encode())
+
+        self.n_comm += 1
+        self.__comm_socket.send(f"open:{comm.comm_id}".encode())
 
 
 class MeshcatWrapper:
-    def __init__(self, zmq_url, comm_url):
+    def __init__(self, zmq_url=None, comm_url=None):
+        # Launch a custom meshcat server if necessary
+        must_launch_server = zmq_url is None
+        self.server_proc = None
+        if must_launch_server:
+            self.server_proc, zmq_url, _, comm_url = start_meshcat_server()
+
+        # Connect to the meshcat server
         with redirect_stdout(None):
             self.gui = meshcat.Visualizer(zmq_url)
         self.__zmq_socket = self.gui.window.zmq_socket
+
+        # Create a backend recorder. It is not fully initialized to reduce
+        # overhead when not used, which is way more usual than the contrary.
         self.recorder = MeshcatRecorder(self.gui.url())
 
         # Create ZMQ socket from/to Ipython Kernel bridge to forward
@@ -42,82 +147,52 @@ class MeshcatWrapper:
         # been chosen to add extra ROUTER/ROUTER sockets instead of replacing
         # the original ones to avoid altering too much the original
         # implementation of Meshcat.
-        self.n_comm = 0
-        self.__n_message = 0
-        try:
+        self.comm_manager = None
+        if must_launch_server and is_notebook():
             self.__kernel = get_ipython().kernel
-        except (NameError, AttributeError):
-            pass  # No backend Ipython kernel available. Not listening for incoming connections.
-        else:
-            def forward_comm_thread():
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                ioloop = tornado.ioloop.IOLoop()
-                context = zmq.Context()
-                self.__comm_socket = context.socket(zmq.XREQ)
-                self.__comm_socket.connect(comm_url)
-                self.__comm_stream = ZMQStream(self.__comm_socket)
-                self.__comm_stream.on_recv(self.__forward_to_ipython)
-                ioloop.start()
-            thread = threading.Thread(target=forward_comm_thread)
-            thread.daemon = True
-            thread.start()
-            self.__kernel.comm_manager.register_target(
-                'meshcat', self.__comm_register)
+            self.comm_manager = CommManager(comm_url)
 
+        # Make sure the server is properly closed
         atexit.register(self.close)
 
     def __del__(self):
         self.close()
 
     def close(self):
-        self.n_comm = 0
-        self.__n_message = 0
+        if self.comm_manager is not None:
+            self.comm_manager.close()
         self.recorder.release()
-        if self.__kernel is not None:
-            self.__kernel.comm_manager.unregister_target(
-                'meshcat', self.__comm_register)
-        self.__comm_stream.close(linger=5)
-        self.__comm_socket.close(linger=5)
-
-    def __forward_to_ipython(self, messages):
-        from IPython import get_ipython
-        comm_pool = get_ipython().kernel.comm_manager.comms
-        cmd = messages[0]
-        comm_id = cmd[:32].decode()  # comm_id is always 32 bits
-        comm_pool[comm_id].send(buffers=[cmd[32:]])
-
-    def __comm_register(self, comm, msg):
-        # There is a major limitation of using 'comm.on_msg' callback
-        # mechanism: if the main thread is already busy for some reason, for
-        # instance waiting for a reply from the server ZMQ socket, then
-        # 'comm.on_msg' will NOT triggered automatically. It is only triggered
-        # automatically once every other tacks has been process. The workaround
-        # is to interleave blocking code with call of 'kernel.do_one_iteration'
-        # or 'await kernel.process_one(wait=True)'. See Stackoverflow for ref.
-        # https://stackoverflow.com/questions/63651823/direct-communication-between-javascript-in-jupyter-and-server-via-ipython-kernel/63666477#63666477
-        @comm.on_msg
-        def _on_msg(msg):
-            self.__n_message += 1
-            data = msg['content']['data']  # TODO: Check compatibility with Google Colab
-            self.__comm_socket.send(f"data:{comm.comm_id}:{data}".encode())
-
-        @comm.on_close
-        def _close(evt):
-            self.n_comm -= 1
-            self.__comm_socket.send(f"close:{comm.comm_id}".encode())
-
-        self.n_comm += 1
-        self.__comm_socket.send(f"open:{comm.comm_id}".encode())
 
     def wait(self, require_client=False):
         if require_client:
-            self.gui.wait()
+            # Calling the original 'wait' method must be avoided
+            # since it is blocking. Here we are waiting for a
+            # new comm to connect. Always perform a single
+            # 'do_one_iteration', just in case there is already
+            # comm waiting in the queue to be registered, but it
+            # should not be necessary.
+            self.__zmq_socket.send(b"wait")
+            if self.comm_manager is None:
+                self.__zmq_socket.recv()
+            else:
+                while True:
+                    try:
+                        # First try, just in case there is already a comm for
+                        # websocket available.
+                        self.__zmq_socket.recv(flags=zmq.NOBLOCK)
+                        break
+                    except zmq.error.ZMQError:
+                        # No websocket nor comm connection available at this
+                        # point. Fetching new incoming messages and retrying.
+                        # By doing this, opening a websocket or comm should
+                        # be enough to successfully recv the acknowledgement.
+                        self.__kernel.do_one_iteration()
 
         self.__zmq_socket.send(b"ready")
-        self.__n_message = 0
-        while self.__n_message < self.n_comm:
-            self.__kernel.do_one_iteration()
+        if self.comm_manager is not None:
+            self.comm_manager.n_message = 0
+            while self.comm_manager.n_message < self.comm_manager.n_comm:
+                self.__kernel.do_one_iteration()
         return self.__zmq_socket.recv().decode("utf-8")
 
     def start_recording(self, fps, width, height):

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -2,9 +2,9 @@ import os
 import numpy as np
 
 from . import core as jiminy
-from .viewer import Viewer
+from .viewer import is_notebook
 
-if Viewer._is_notebook():
+if is_notebook():
     from tqdm.notebook import tqdm
 else:
     from tqdm import tqdm

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -482,9 +482,8 @@ class Viewer:
                 viewer instance.
         """
         try:
-            if Viewer.backend == 'meshcat' and Viewer._backend_obj:
-                zmq_socket = Viewer._backend_obj.gui.window.zmq_socket
-                zmq_socket.RCVTIMEO = 50
+            if Viewer.backend == 'meshcat' and Viewer._backend_obj is not None:
+                Viewer._backend_obj.gui.window.zmq_socket.RCVTIMEO = 50
             if self is None:
                 self = Viewer
             else:
@@ -509,6 +508,7 @@ class Viewer:
                 if Viewer.is_open():
                     Viewer._backend_proc.kill()
                 Viewer._backend_obj = None
+                Viewer._backend_proc = None
             else:
                 self.__is_open = False
             if self._tempdir.startswith(tempfile.gettempdir()):
@@ -516,8 +516,8 @@ class Viewer:
                     shutil.rmtree(self._tempdir)
                 except FileNotFoundError:
                     pass
-            if Viewer.backend == 'meshcat' and Viewer._backend_obj:
-                zmq_socket.RCVTIMEO = -1
+            if Viewer.backend == 'meshcat' and Viewer._backend_obj is not None:
+                Viewer._backend_obj.gui.window.zmq_socket.RCVTIMEO = -1
         except:
             pass
 
@@ -728,13 +728,13 @@ class Viewer:
 
             # Launch a meshcat custom server if none has been found
             if zmq_url is None:
-                proc, zmq_url, _ = start_meshcat_server()
+                proc, zmq_url, _, comm_url = start_meshcat_server()
             else:
                 proc = psutil.Process(conn.pid)
             proc = ProcessWrapper(proc, close_at_exit)
 
             # Connect to the zmq server
-            client = MeshcatWrapper(zmq_url)
+            client = MeshcatWrapper(zmq_url, comm_url)
 
             return client, proc
 

--- a/python/jiminy_py/src/jiminy_py/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer.py
@@ -995,7 +995,7 @@ class Viewer:
                             visual, pin.GeometryType.VISUAL)].set_transform(T)
                 self.__update_camera_transform()
         if wait and Viewer.backend == 'meshcat':  # Gepetto-gui is already synchronous
-            Viewer._backend_obj.gui.wait()
+            Viewer._backend_obj.wait()
 
     @__must_be_open
     def display(self, q, xyz_offset=None, wait=False):
@@ -1021,7 +1021,7 @@ class Viewer:
             self.__update_camera_transform()
         pin.framesForwardKinematics(self._rb.model, self._rb.data, q)  # This method is not called automatically by 'display' method
         if wait and Viewer.backend == 'meshcat':  # Gepetto-gui is already synchronous
-            Viewer._backend_obj.gui.wait()
+            Viewer._backend_obj.wait()
 
     def replay(self,
                evolution_robot,


### PR DESCRIPTION
### New features and improvements:

- [Viewer] Native and full support of Jupyter, using directly kernel communication to avoid websockets and port forward all together. It should work on Google Colab but it cannot be tested easily (must be installed using wheel)
- [Viewer] Remove the support of port forwarding, since it is not longer relevant
- [Viewer] Create display cell in notebook mode when instantiating a viewer while no display cell is already available
- [Viewer] Check for browser availability when calling 'open_gui', and wait for the client to be ready

### Bug fixes and improvements:

- [Viewer] Avoid timeout on low-hand machine while starting video recording
- [Viewer] Improve the reliability of running Meshcat server detection. Remove heartbeat check since it is impossible to estimate appropriate response time (It can take a while if the meshes are already loading in a display cell for instance).

Various other minor fixes.

### Side notes:

Bi-directional communication between frontend javascript and backend zmq is a bit tricky to achieve. It comes from the fact that the handling of incoming communications (including connection requests) are handled by the main thread, so it is not impossible to wait for a message through zmq socket, while waiting for an incoming reply from the kernel communications. More generally, it is impossible to do any multitasking, ie starting to monitor an new jupyter display while a replay loop is already running. Moreover, since the callback cannot interrupt the main thread, if the reply of a simulation has already started then a new display cell will stay empty since the opening notification will be received by the server only at the end. [#stackoverflow](https://stackoverflow.com/questions/63651823/direct-communication-between-javascript-in-jupyter-and-server-via-ipython-kernel) [#ipykernel](https://github.com/ipython/ipykernel/issues/542)

To circumvent those limitations, 'kernel.do_one_iteration' is interleaved 'zmq_socket.recv', so that incoming messages can be processed on the spot. The only issue doing this is that every request from the kernel will also be processed, including that queued cell evaluation. If there is any, it will corrupt the stack and Jupyter will throw an error (recoverable). It would be possible to avoid it by analysing the messages in the stack, only process 'comm_*', and put back in the stack the other ones. This is out of the scope of the PR.

