### PR TITLE
[Viewer] Fix kernel exception and stack corruption in notebooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.3.5)
+set(BUILD_VERSION 1.3.6)
 
 # Add definition of Jiminy version for C++ headers
 add_definitions("-DJIMINY_VERSION=\"${BUILD_VERSION}\"")

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -29,7 +29,7 @@ setup(name = 'jiminy_py',
       packages = find_packages('src'),
       package_dir = {'': 'src'},
       package_data = {'jiminy_py': ['**/*.dll', '**/*.so', '**/*.pyd', '**/*.html', '**/*.js']},
-      entry_points={'console_scripts': [
+      entry_points = {'console_scripts': [
           'jiminy_plot=jiminy_py.log:plot_log',
           'jiminy_meshcat_server=jiminy_py.meshcat.server:start_meshcat_server_standalone'
       ]},


### PR DESCRIPTION
####  Patches and bug fixes:

- [Viewer] Only process kernel comm messages on the spot to avoid messing up . 
- [Viewer] Do not examine Ipython port while looking for ZMQ Meshcat to avoid throwing a low-level kernel exception.

Fix #187 side-effects