### PR TITLE
[Viewer] More robust server to frontend forwarding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.3.7)
+set(BUILD_VERSION 1.3.8)
 
 # Add definition of Jiminy version for C++ headers
 add_definitions("-DJIMINY_VERSION=\"${BUILD_VERSION}\"")

--- a/python/jiminy_py/src/jiminy_py/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/meshcat/index.html
@@ -48,6 +48,7 @@
                         viewer.handle_command_bytearray(new Uint8Array(message.buffers[0].buffer));
                     });
                     viewer.connection.on_close(function(message) {
+                        viewer.connection = null;  // The connection is no longer available
                         console.log("connection to Jupyter kernel closed:", message);
                     });
                 }
@@ -123,8 +124,15 @@
             start_animate();
 
             window.onunload = function(event) {
-                console.log("Closing connection...")
-                viewer.connection.close();
+                // Only close the connection if it is still open.
+                // Note that it is still possible that "on_close" method has
+                // not been triggered and that the connection is no longer
+                // available.
+                if (viewer.connection !== null)
+                {
+                    console.log("Closing connection...");
+                    viewer.connection.close();
+                }
                 return false;
             }
         </script>

--- a/python/jiminy_py/src/jiminy_py/meshcat/server.py
+++ b/python/jiminy_py/src/jiminy_py/meshcat/server.py
@@ -133,11 +133,11 @@ class ZMQWebSocketIpythonBridge(ZMQWebSocketBridge):
     def handle_comm(self, frames):
         cmd = frames[0].decode("utf-8")
         if cmd.startswith("open:"):
-            comm_id = f"{cmd.split(':', 1)[1]}"
+            comm_id = f"{cmd.split(':', 1)[1]}".encode()
             self.send_scene(comm_id=comm_id)
             self.comm_pool.add(comm_id)
         elif cmd.startswith("close:"):
-            comm_id = f"{cmd.split(':', 1)[1]}"
+            comm_id = f"{cmd.split(':', 1)[1]}".encode()
             self.comm_pool.remove(comm_id)
         elif cmd.startswith("data:"):
             message = f"{cmd.split(':', 2)[2]}"
@@ -164,7 +164,7 @@ class ZMQWebSocketIpythonBridge(ZMQWebSocketBridge):
             self.forward_to_comm(comm_id, data)
 
     def forward_to_comm(self, comm_id, message):
-        self.comm_zmq.send(comm_id.encode() + message)
+        self.comm_zmq.send_multipart([comm_id, message])
 
     def send_scene(self, websocket=None, comm_id=None):
         if websocket is not None:


### PR DESCRIPTION
#### Patches and bug fixes:

- [Viewer] Do not rely on knowing the expected comm_id size in byte 
- [Viewer] Handle already closed connections properly.
- [Viewer] Add warning to recommand increasing 'iopub_msg_rate_limit' for notebooks (Done by default on Google Colab)